### PR TITLE
fix: fix casing of crowdstrike vendor name

### DIFF
--- a/package/crowdstrike/index.yml
+++ b/package/crowdstrike/index.yml
@@ -1,6 +1,6 @@
 code: crowdstrike
 status: verified
-name: Crowdstrike
+name: CrowdStrike
 type: vendor
 url: https://www.crowdstrike.com/
 description: CrowdStrike is a global cybersecurity leader with an advanced cloud-native platform for protecting endpoints, cloud workloads, identities and data.

--- a/package/crowdstrike/npm-shrinkwrap.json
+++ b/package/crowdstrike/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/vendor-crowdstrike",
-  "version": "1.1.5",
+  "version": "1.1.6-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/vendor-crowdstrike",
-      "version": "1.1.5",
+      "version": "1.1.6-rc.0",
       "license": "ISC"
     }
   }

--- a/package/crowdstrike/package.json
+++ b/package/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-crowdstrike",
-  "version": "1.1.5",
+  "version": "1.1.6-rc.0",
   "description": "Vendor package for crowdstrike",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
Simple name fix (from Crowdstrike to CrowdStrike) for consistency since I am going to load the entire CrowdStrike product portfolio next, including two suites that reference the vendor name in their index.yml file.