### PR TITLE
feat: enforce ^[a-z0-9]+$ on vendor codes

### DIFF
--- a/.claude/skills/create-vendor.md
+++ b/.claude/skills/create-vendor.md
@@ -162,6 +162,8 @@ mkdir -p package/{vendorCode}
 cd package/{vendorCode}
 ```
 
+**Code format:** `{vendorCode}` must match `^[a-z0-9]+$` — lowercase alphanumeric only, no hyphens/underscores/dots (matches ZB platform `vspCodeValidator`).
+
 **Required files:**
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Each vendor package (`package/[vendor-name]/`) contains:
 - **Commit Format**: All commits must follow Conventional Commits specification
 - **Private Registry**: Packages publish to `npm.pkg.github.com/@zerobias-org`
 - **No Direct npm publish**: Always use `npm run nx:publish` to ensure dependencies are correct
-- **Vendor Naming**: Package names should match the pattern `@zerobias-org/vendor-[name]`
+- **Vendor Naming**: Package names must match `@zerobias-org/vendor-{code}` where `{code}` matches `^[a-z0-9]+$` — **lowercase alphanumeric only, no hyphens/underscores/dots** (matches ZB platform `vspCodeValidator`)
 
 ---
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -79,6 +79,10 @@ async function processIndexYml(indexFile: Record<string, any>): Promise<{ code: 
   if (typeof code !== 'string') {
     throw new Error('code in index.yml needs replacement from {code}');
   }
+  // Enforce ^[a-z0-9]+$ — matches ZB platform vspCodeValidator (no hyphens, underscores, or dots)
+  if (!/^[a-z0-9]+$/.test(code)) {
+    throw new Error(`code "${code}" contains invalid characters. Must match ^[a-z0-9]+$ (lowercase alphanumeric only — no hyphens, underscores, or dots).`);
+  }
 
   let check: any;
   check = indexFile.id !== undefined && indexFile.id !== null && indexFile.id !== '{id}' ? new UUID(indexFile.id)


### PR DESCRIPTION
## Summary

Adds `^[a-z0-9]+$` regex validation for vendor code in `validate.ts`. Matches the ZB platform UI's `vspCodeValidator` constraint: lowercase alphanumeric only, no hyphens, underscores, or dots.

Companion PRs:
- zerobias-org/schema#11 (schema repo)
- zerobias-org/product#13 (product repo)

### Changes
- `scripts/validate.ts`: Added regex check on code after extraction from index.yml
- `CLAUDE.md`: Updated vendor naming note with explicit constraint
- `.claude/skills/create-vendor.md`: Added code format note

🤖 Generated with [Claude Code](https://claude.com/claude-code)