### PR TITLE
fix(ci) + feat(vendor)!: align dist-tag + bump 6 vendors to 2.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           packages-file: /tmp/published-packages.json
           branch: ${{ github.ref_name }}
-          dist-tag: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'qa' && 'rc' || github.ref_name == 'dev' && 'dev' || 'uat' }}
+          dist-tag: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'dev' && 'dev' || 'uat' }}
         env:
           SLACK_RELEASES_WEBHOOK: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
           SLACK_DEVOPS_NOTIFICATIONS: ${{ secrets.SLACK_DEVOPS_NOTIFICATIONS }}

--- a/package/amazon/package.json
+++ b/package/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-amazon",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for amazon",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/avigilon/package.json
+++ b/package/avigilon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-avigilon",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "description": "Vendor package for Avigilon",
   "author": "ctamas@zerobias.com",
   "license": "ISC",

--- a/package/github/package.json
+++ b/package/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-github",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for github",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/google/package.json
+++ b/package/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-google",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for google",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/microsoft/package.json
+++ b/package/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-microsoft",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for microsoft",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/zerobias/package.json
+++ b/package/zerobias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zerobias",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Cyber, Digital and Risk assessor data and automation platform",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary
Two changes bundled for the dev → qa → main path:

1. **fix(ci):** `.github/workflows/publish.yml` — Slack release-announcement reported `rc` as the qa dist-tag, but zb.content/zb.base publishes qa builds under the `qa` dist-tag (no `rc` written). Switch the qa announcement string `rc` → `qa` so it matches the actual published tag. Cleaned the dangling legacy `rc` tag off the 6 already-published vendors via `npm dist-tag rm` out of band.

2. **feat(vendor)!:** Major-bump the six gradle-migrated vendors to `2.0.0` (BREAKING CHANGE):
   - github / amazon / microsoft / google: `1.0.13` → `2.0.0`
   - zerobias: `1.0.6` → `2.0.0`
   - avigilon: `1.1.5` → `2.0.0`

   Treats the gradle/zb.content publish path as a clean starting point distinct from the prior lerna-based 1.x line. Aligns major across the cohort so `2.x.*` tracks the gradle pipeline and legacy `1.x.*` stays pinnable.

## Verification context
- dev publish run [25016536694](https://github.com/zerobias-org/vendor/actions/runs/25016536694) — published `1.0.13-dev.0` (pre-bump) ✅
- qa publish run [25016765437](https://github.com/zerobias-org/vendor/actions/runs/25016765437) — published `1.0.13-rc.0` (pre-bump) ✅
- After this PR merges through dev → qa → main, expected next publishes: `2.0.0-dev.0`, `2.0.0-rc.0`, `2.0.0`.

## Test plan
- [ ] dev `Publish` produces `2.0.0-dev.0` versions tagged `dev`
- [ ] qa `Publish` produces `2.0.0-rc.0` versions tagged `dev` + `qa` (cumulative promote)
- [ ] main `Publish` produces `2.0.0` versions tagged through `dev` + `qa` + `uat` + `latest`
- [ ] Slack announcement on qa shows `dist-tag: qa` (was `rc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)