### PR TITLE
chore: dev → qa (2.0.0 baseline + dist-tag fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           packages-file: /tmp/published-packages.json
           branch: ${{ github.ref_name }}
-          dist-tag: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'qa' && 'rc' || github.ref_name == 'dev' && 'dev' || 'uat' }}
+          dist-tag: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'qa' && 'qa' || github.ref_name == 'dev' && 'dev' || 'uat' }}
         env:
           SLACK_RELEASES_WEBHOOK: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
           SLACK_DEVOPS_NOTIFICATIONS: ${{ secrets.SLACK_DEVOPS_NOTIFICATIONS }}

--- a/package/amazon/package.json
+++ b/package/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-amazon",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for amazon",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/avigilon/package.json
+++ b/package/avigilon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-avigilon",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "description": "Vendor package for Avigilon",
   "author": "ctamas@zerobias.com",
   "license": "ISC",

--- a/package/github/package.json
+++ b/package/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-github",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for github",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/google/package.json
+++ b/package/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-google",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for google",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/microsoft/package.json
+++ b/package/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-microsoft",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for microsoft",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/zerobias/package.json
+++ b/package/zerobias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zerobias",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Cyber, Digital and Risk assessor data and automation platform",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary
Promotes dev to qa. Carries:
- **#43** fix(ci) + feat(vendor)!: announcement dist-tag `rc → qa`, plus 2.0.0 major bump for the 6 gradle-migrated vendors (github, amazon, microsoft, google, zerobias, avigilon)

## Verification on dev
Run [25017988755](https://github.com/zerobias-org/vendor/actions/runs/25017988755) — all 6 vendor jobs ✅. Registry verified: `2.0.0-dev.0` is live for each vendor under the `dev` dist-tag.

## Test plan
- [ ] qa publish produces `2.0.0-rc.0` versions, dist-tagged `dev` + `qa`
- [ ] If green, follow-up qa → main