### PR TITLE
fix(ci): serialize per-vendor publish jobs to avoid pushVersion race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,15 @@ jobs:
       ZB_SLOT: ci-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
+      # Serialized: every per-vendor job runs `commitVersion` + `tagVersion` +
+      # `git push --follow-tags` against `main`. Running matrix entries in
+      # parallel races on that push — only the first job wins, the rest hit
+      # fast-forward rejection and the rebase fallback can't proceed because
+      # the tree is dirty (npm publish auto-corrects package.json, dataloader
+      # leaves node_modules/ etc.). Serializing avoids the race entirely.
+      # Trade-off: 6 vendors * ~3min = ~18min total instead of ~3min parallel.
+      # Acceptable at this size; revisit if vendor counts climb significantly.
+      max-parallel: 1
       matrix:
         vendor: ${{ fromJson(needs.detect.outputs.vendors) }}
     steps:


### PR DESCRIPTION
## Summary
Add `max-parallel: 1` to the `publish` job's matrix so per-vendor jobs run sequentially instead of racing on the `git push --follow-tags` in `zb.base.pushVersion`.

## Why
Reproduced on the first main publish after the gradle migration landed: run [25018847869](https://github.com/zerobias-org/vendor/actions/runs/25018847869). Five of six vendor jobs failed at `:<vendor>:pushVersion`:

```
Push attempt 1/5 failed: Command failed (exit 1): git push --follow-tags
error: failed to push some refs to 'https://github.com/zerobias-org/vendor'
> pushVersion: rebase failed after push rejection — manual reconciliation required
  error: cannot pull with rebase: You have unstaged changes.
```

Two failure modes layered on top of each other:
1. Multiple jobs push to `main` in parallel — only the first wins, the rest hit fast-forward rejection.
2. The rebase fallback in `zb.base.pushVersion` can't proceed because the working tree is dirty (npm publish auto-corrects `package.json`, dataloader leaves `node_modules/` + various artifacts behind).

The npm artifacts ended up published correctly (`@zerobias-org/vendor-X@2.0.0` are all on the registry under `latest`), but the git tags and release commits never landed and had to be created manually after the fact.

## Fix
`max-parallel: 1` makes the matrix run one vendor at a time. No more race; each push sees an unmoved `main`. Trade-off: 6 vendors * ~3min = ~18min total instead of ~3min parallel. Acceptable at this scale — revisit if vendor counts climb significantly.

## Long-term follow-ups (not in this PR)
1. Collapse `pushVersion` into a single tail job that runs after all parallel publishes finish — keeps publish work parallel, only serializes the git-side bookkeeping.
2. Make the rebase fallback in `zb.base.pushVersion` stash-aware so the dirty tree doesn't block recovery (defense-in-depth).

## Test plan
- [ ] Trigger publish on dev — single vendor still publishes the same way (no regression for one-vendor diffs)
- [ ] Trigger publish with multiple changed vendors — jobs run sequentially, no fast-forward rejections, all `pushVersion` tasks succeed
- [ ] Confirm release commits + tags land for every vendor on main