### PR TITLE
fix(vendors): normalize repository.url to stop npm publish auto-correcting

### DIFF
--- a/package/amazon/package.json
+++ b/package/amazon/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zerobias-org/vendor.git",
+    "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
     "directory": "vendor/"
   },
   "scripts": {

--- a/package/avigilon/package.json
+++ b/package/avigilon/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zerobias-org/vendor.git",
+    "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
     "directory": "package/avigilon/"
   },
   "scripts": {

--- a/package/github/package.json
+++ b/package/github/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zerobias-org/vendor.git",
+    "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
     "directory": "vendor/"
   },
   "scripts": {

--- a/package/google/package.json
+++ b/package/google/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zerobias-org/vendor.git",
+    "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
     "directory": "vendor/"
   },
   "scripts": {

--- a/package/microsoft/package.json
+++ b/package/microsoft/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zerobias-org/vendor.git",
+    "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
     "directory": "vendor/"
   },
   "scripts": {

--- a/package/zerobias/package.json
+++ b/package/zerobias/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git@github.com:zerobias-org/vendor.git",
+    "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
     "directory": "package/zerobias/"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
Run `npm pkg fix` on the 6 gradle-migrated vendor `package.json` files to normalize `repository.url`:

```diff
- "url": "git@github.com:zerobias-org/vendor.git",
+ "url": "git+ssh://git@github.com/zerobias-org/vendor.git",
```

Single-line normalization per file, no semantic change.

## Why
On the first main publish after the gradle migration ([run 25018847869](https://github.com/zerobias-org/vendor/actions/runs/25018847869)), 5 of 6 vendor jobs failed at `:<vendor>:pushVersion`:

```
> pushVersion: rebase failed after push rejection — manual reconciliation required
  error: cannot pull with rebase: You have unstaged changes.
```

Trace the chain:
1. `npm publish` emits `npm warn publish npm auto-corrected some errors in your package.json when publishing. Please run "npm pkg fix" to address these errors.` → mutates `package.json` (a tracked file).
2. `commitVersion` already committed `package.json` before publish ran → working tree is now dirty.
3. The matrix runs vendors in parallel → fast-forward push rejection → `pushVersion` falls back to `git pull --rebase origin main` → fails because of the dirty tree.

[Module's run 24749849230](https://github.com/auditlogic/module/actions/runs/24749849230/job/72410361135) shows the same race fires on module too — but the rebase retry **works** there because module's `package.json` files are npm-clean, so the tree stays clean during publish.

Fix at the source instead of forking the workflow / patching the gradle task.

## Out of scope (follow-ups)
- Same `npm pkg fix` cleanup needs to run on the other ~440 vendor `package.json` files before each cohort moves to gradle, otherwise the first main publish for that cohort will hit the same race.
- Defense-in-depth: stash-aware rebase fallback in `zb.base.pushVersion` — separate `org/util` PR, not blocking this.

## Test plan
- [ ] Re-trigger publish chain dev → qa → main. `npm publish` no longer prints the auto-correct warning.
- [ ] If two of these vendors land on main concurrently, `pushVersion` retry path resolves cleanly (matches module's behavior).