### PR TITLE
fix(vendors): commit gate-stamps for 17 credential issuers

### DIFF
--- a/package/a2la/gate-stamp.json
+++ b/package/a2la/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ansi/gate-stamp.json
+++ b/package/ansi/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/caico/gate-stamp.json
+++ b/package/caico/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/comptia/gate-stamp.json
+++ b/package/comptia/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/crest/gate-stamp.json
+++ b/package/crest/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cyberab/gate-stamp.json
+++ b/package/cyberab/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eccouncil/gate-stamp.json
+++ b/package/eccouncil/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fitsi/gate-stamp.json
+++ b/package/fitsi/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/giac/gate-stamp.json
+++ b/package/giac/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hitrust/gate-stamp.json
+++ b/package/hitrust/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iapp/gate-stamp.json
+++ b/package/iapp/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/irca/gate-stamp.json
+++ b/package/irca/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/isc2/gate-stamp.json
+++ b/package/isc2/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/mile2/gate-stamp.json
+++ b/package/mile2/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/offsec/gate-stamp.json
+++ b/package/offsec/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/saico/gate-stamp.json
+++ b/package/saico/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/scf/gate-stamp.json
+++ b/package/scf/gate-stamp.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "branch": "feat/gradle-marker-credential-issuers",
+  "timestamp": "2026-04-28T16:57:49.000Z",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}


### PR DESCRIPTION
## Summary
Stub `gate-stamp.json` for the 17 credential issuer vendors that landed in #39 + got their gradle marker in #47. Without a committed stamp, `zb.content`'s `zbb publish` preflight fails with:

> gate-stamp.json is missing or invalid — run zbb gate locally and commit the stamp before publishing

Reproduced immediately on dev publish run [25066294967](https://github.com/zerobias-org/vendor/actions/runs/25066294967) — ansi/scf/a2la/irca failed preflight at this exact spot.

## Stamp content
Same shape as the stamps committed for the original 6 gradle-migrated vendors (github/amazon/microsoft/google/zerobias/avigilon). For content packages the source-hash is always `SHA-256("")` = `e3b0c44298…` because the hash is computed over `api.yml` + `tsconfig.json` + `src/` — none of which exist in vendor packages. The CI gate recomputes and validates the hash on every run.

## Follow-up
The stub-stamp dance is a known wart, tracked in [zerobias-org/util#61](https://github.com/zerobias-org/util/issues/61) — that issue captures the design for making stamping a per-plugin lifecycle function so content packages can hash their actual surface (`index.yml`, `logo.*`, package.json sans version) instead of the empty-set default. Once that lands, the skill's Step 12 will write the right stamp automatically and this kind of stub commit goes away.

## Test plan
- [ ] Re-trigger dev publish — preflight passes for all 17, gate runs, publish + promote succeed.
- [ ] Confirm `npm view @zerobias-org/vendor-<each>@latest` returns 1.0.0 after qa→main promotion.