### PR TITLE
fix(vendor-irca): drop invalid 'cqi' tag (dataloader rejects non-UUID tag values)

### DIFF
--- a/package/irca/index.yml
+++ b/package/irca/index.yml
@@ -11,8 +11,7 @@ created: 2026-04-24T00:00:00.000Z
 updated: 2026-04-24T00:00:00.000Z
 status: verified
 url: https://www.quality.org/
-tags:
-  - cqi
+tags: []
 aliases:
   - International Register of Certificated Auditors
   - CQI-IRCA


### PR DESCRIPTION
## Summary
Set `tags: []` on irca's `index.yml` (was `tags: ['cqi']`).

## Why
The dataloader expects each `tags:` entry to be a UUID referencing the platform's tag catalog. irca's bare string `cqi` triggered:

```
Unable to handle vendor 'IRCA', tag cqi is not a valid UUID
```

— the only failure in [run 25066476278](https://github.com/zerobias-org/vendor/actions/runs/25066476278) (22/23 publishes succeeded). The other 16 credential issuers use `tags: []` and passed.

If we later want to semantically tag IRCA with "CQI", we'd add a CQI entry to the platform tag catalog and reference its UUID here.