### PR TITLE
feat(vendor)!: migrate 5 vendors (accelq, action1, adobe, akamai, anchore) to gradle 2.0.0

### DIFF
--- a/package/accelq/build.gradle.kts
+++ b/package/accelq/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/accelq/package.json
+++ b/package/accelq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-accelq",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for ACCELQ",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/action1/build.gradle.kts
+++ b/package/action1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/action1/package.json
+++ b/package/action1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-action1",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Action1",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/adobe/build.gradle.kts
+++ b/package/adobe/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/adobe/package.json
+++ b/package/adobe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-adobe",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Adobe empowers everyone, everywhere to imagine, create, and bring any digital experience to life. From creators and students to small businesses, global enterprises, and nonprofit organizations",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/akamai/build.gradle.kts
+++ b/package/akamai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/akamai/package.json
+++ b/package/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-akamai",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Akamai",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/anchore/build.gradle.kts
+++ b/package/anchore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/anchore/package.json
+++ b/package/anchore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-anchore",
-  "version": "0.2.7",
+  "version": "2.0.0",
   "description": "Vendor package for anchore",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary
Small batch test of the gradle migration flow on main now that the inline SchemaPrimitives validator landed in #53.

5 vendors picked from alphabetical front (across 1.x and 0.x version histories):

| vendor | prior | new |
|---|---|---|
| accelq | 1.2.2 | 2.0.0 |
| action1 | 1.2.2 | 2.0.0 |
| adobe | 1.0.6 | 2.0.0 |
| akamai | 1.0.2 | 2.0.0 |
| anchore | 0.2.7 | 2.0.0 |

Each gets the one-line `plugins { id("zb.content") }` marker plus a 2.0.0 version bump per the migration major-bump rule.

## What this tests
- `detect` job picks up exactly the 5 changed vendors (not the 23 already on main, not the 436 untouched)
- inline validator from build.gradle.kts (composed from SchemaPrimitives) runs cleanly in CI
- full gate (validate + dataloader on ephemeral Neon branch) passes for non-credential-issuer vendor shapes
- cumulative `promoteAll` to dev/qa/uat/latest works for the 5 in parallel

## Validation
- [x] `./gradlew :{vendor}:validateContent` passes locally for all 5
- [ ] CI gate passes (validate + dataloader)
- [ ] All 5 publish 2.0.0 with `latest` dist-tag
- [ ] Platform load on prod confirms 5 new vendor records

## Type
BREAKING CHANGE: 1.x -> 2.0.0 jump (lerna era -> gradle era)