### PR TITLE
feat: migrate 10 vendors to gradle (aicpa, aiuc, aiven, allgress, apachesoftwarefoundation, appdome, apple, apptio, aquasec, armorcode)

### DIFF
--- a/package/aicpa/build.gradle.kts
+++ b/package/aicpa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aicpa/gate-stamp.json
+++ b/package/aicpa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/aicpa/package.json
+++ b/package/aicpa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-aicpa",
-  "version": "1.0.10",
+  "version": "2.0.0",
   "description": "Vendor package for aicpa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/aiuc/build.gradle.kts
+++ b/package/aiuc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aiuc/gate-stamp.json
+++ b/package/aiuc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/aiuc/package.json
+++ b/package/aiuc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-aiuc",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Vendor package for AIUC (AI Use Case Consortium)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/aiven/build.gradle.kts
+++ b/package/aiven/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aiven/gate-stamp.json
+++ b/package/aiven/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/aiven/package.json
+++ b/package/aiven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-aiven",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for aiven",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/allgress/build.gradle.kts
+++ b/package/allgress/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/allgress/gate-stamp.json
+++ b/package/allgress/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/allgress/package.json
+++ b/package/allgress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-allgress",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for allgress",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/apachesoftwarefoundation/build.gradle.kts
+++ b/package/apachesoftwarefoundation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/apachesoftwarefoundation/gate-stamp.json
+++ b/package/apachesoftwarefoundation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/apachesoftwarefoundation/package.json
+++ b/package/apachesoftwarefoundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-apachesoftwarefoundation",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Apache Software Foundation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/appdome/build.gradle.kts
+++ b/package/appdome/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/appdome/gate-stamp.json
+++ b/package/appdome/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/appdome/package.json
+++ b/package/appdome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-appdome",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Appdome",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/apple/build.gradle.kts
+++ b/package/apple/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/apple/gate-stamp.json
+++ b/package/apple/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/apple/package.json
+++ b/package/apple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-apple",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Apple",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/apptio/build.gradle.kts
+++ b/package/apptio/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/apptio/gate-stamp.json
+++ b/package/apptio/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/apptio/package.json
+++ b/package/apptio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-apptio",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for apptio",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/aquasec/build.gradle.kts
+++ b/package/aquasec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aquasec/gate-stamp.json
+++ b/package/aquasec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/aquasec/package.json
+++ b/package/aquasec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-aquasec",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Secure Every Cloud Native Application Everywhere",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/armorcode/build.gradle.kts
+++ b/package/armorcode/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/armorcode/gate-stamp.json
+++ b/package/armorcode/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-next",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/armorcode/package.json
+++ b/package/armorcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-armorcode",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for ArmorCode",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Migrates 10 vendors from the legacy lerna flow to the gradle (`zb.content`) + `zbb-publish-reusable.yml` pipeline. Universal major bump on first gradle publish.

| vendor | old → new |
|---|---|
| aicpa | 1.0.10 → 2.0.0 |
| aiuc | 1.1.2 → 2.0.0 |
| aiven | 1.0.13 → 2.0.0 |
| allgress | 1.0.12 → 2.0.0 |
| apachesoftwarefoundation | 1.0.4 → 2.0.0 |
| appdome | 1.2.2 → 2.0.0 |
| apple | 1.0.4 → 2.0.0 |
| apptio | 1.0.13 → 2.0.0 |
| aquasec | 1.0.6 → 2.0.0 |
| armorcode | 1.2.2 → 2.0.0 |

Per-package: `build.gradle.kts` marker (`plugins { id("zb.content") }`), version bump, committed `gate-stamp.json` (preflight requires it).

**Skipped from initial candidate set**:
- `ae` — `logo.svg` is 224B (under 500B floor; likely S3 404 page). Needs separate fix.
- `aikido` — `logo.svg` is 392B (under 500B floor). Needs separate fix.

These were swapped for `aquasec` and `armorcode`.

## Test plan

- [x] `./gradlew :<v>:gate` passes for each of the 10 (logos in range, package.json identity triangulation, unique IDs across all 464 vendors)
- [ ] After merge: workflow `publish` runs, version-job is a no-op (already at 2.0.0), publish job promotes each via `publishNpmExec → promoteNpm` (now correctly ordered after the `mustRunAfter` fix in `org/util@2c03505`)
- [ ] `refresh-bundle` updates `@zerobias-org/vendor-bundle` to include all 10 at 2.0.0 (patch-bumps to 1.0.1)