### PR TITLE
feat: migrate vendor batch 2 (asana, asciicorporation, atlassian, au, auditmation, automox, auvik, avepoint, bamboohr, barracuda)

### DIFF
--- a/package/asana/build.gradle.kts
+++ b/package/asana/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/asana/gate-stamp.json
+++ b/package/asana/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/asana/package.json
+++ b/package/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-asana",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for asana",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/asciicorporation/build.gradle.kts
+++ b/package/asciicorporation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/asciicorporation/gate-stamp.json
+++ b/package/asciicorporation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/asciicorporation/package.json
+++ b/package/asciicorporation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-asciicorporation",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for ASCII Corporation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/atlassian/build.gradle.kts
+++ b/package/atlassian/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/atlassian/gate-stamp.json
+++ b/package/atlassian/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/atlassian/package.json
+++ b/package/atlassian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-atlassian",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for atlassian",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/au/build.gradle.kts
+++ b/package/au/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/au/gate-stamp.json
+++ b/package/au/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/au/package.json
+++ b/package/au/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-au",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for au",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/auditmation/build.gradle.kts
+++ b/package/auditmation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/auditmation/gate-stamp.json
+++ b/package/auditmation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/auditmation/package.json
+++ b/package/auditmation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-auditmation",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for auditmation",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/automox/build.gradle.kts
+++ b/package/automox/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/automox/gate-stamp.json
+++ b/package/automox/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/automox/package.json
+++ b/package/automox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-automox",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Automox",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/auvik/build.gradle.kts
+++ b/package/auvik/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/auvik/gate-stamp.json
+++ b/package/auvik/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/auvik/package.json
+++ b/package/auvik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-auvik",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Vendor package for auvik",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/avepoint/build.gradle.kts
+++ b/package/avepoint/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/avepoint/gate-stamp.json
+++ b/package/avepoint/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/avepoint/package.json
+++ b/package/avepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-avepoint",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for AvePoint",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/bamboohr/build.gradle.kts
+++ b/package/bamboohr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bamboohr/gate-stamp.json
+++ b/package/bamboohr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bamboohr/package.json
+++ b/package/bamboohr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-bamboohr",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for bamboohr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/barracuda/build.gradle.kts
+++ b/package/barracuda/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/barracuda/gate-stamp.json
+++ b/package/barracuda/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/barracuda/package.json
+++ b/package/barracuda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-barracuda",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Barracuda Networks",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Next batch of 10 vendors to gradle (`zb.content`) + zbb publish pipeline. Universal major bump.

| vendor | old → new |
|---|---|
| asana | 1.0.13 → 2.0.0 |
| asciicorporation | 1.2.2 → 2.0.0 |
| atlassian | 1.0.13 → 2.0.0 |
| au | 1.0.4 → 2.0.0 |
| auditmation | 1.0.12 → 2.0.0 |
| automox | 1.2.2 → 2.0.0 |
| auvik | 0.2.6 → 1.0.0 |
| avepoint | 1.0.4 → 2.0.0 |
| bamboohr | 1.0.12 → 2.0.0 |
| barracuda | 1.0.4 → 2.0.0 |

**Skipped from candidate set** (logo issues — needs separate fix):
- `at` (218B), `be` (182B) — under 500B floor
- `beanstalk`, `blackduck`, `blueyonder` — no logo file present

## Test plan

- [x] `./gradlew :<v>:gate` passes for each of the 10
- [ ] After merge: matrix publish, bundle auto-refresh to 1.0.2