### PR TITLE
feat: migrate vendor batch 3 (20 vendors: base44 → clockify)

### DIFF
--- a/package/base44/build.gradle.kts
+++ b/package/base44/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/base44/gate-stamp.json
+++ b/package/base44/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/base44/package.json
+++ b/package/base44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-base44",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Base44",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/beyondtrust/build.gradle.kts
+++ b/package/beyondtrust/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/beyondtrust/gate-stamp.json
+++ b/package/beyondtrust/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/beyondtrust/package.json
+++ b/package/beyondtrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-beyondtrust",
-  "version": "0.3.7",
+  "version": "1.0.0",
   "description": "Vendor package for beyondtrust",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/bitdefender/build.gradle.kts
+++ b/package/bitdefender/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bitdefender/gate-stamp.json
+++ b/package/bitdefender/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bitdefender/package.json
+++ b/package/bitdefender/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-bitdefender",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Bitdefender",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/bm/build.gradle.kts
+++ b/package/bm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bm/gate-stamp.json
+++ b/package/bm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bm/package.json
+++ b/package/bm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-bm",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for bm",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/box/build.gradle.kts
+++ b/package/box/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/box/gate-stamp.json
+++ b/package/box/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/box/package.json
+++ b/package/box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-box",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for box",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/br/build.gradle.kts
+++ b/package/br/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/br/gate-stamp.json
+++ b/package/br/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/br/package.json
+++ b/package/br/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-br",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for br",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/bsi/build.gradle.kts
+++ b/package/bsi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bsi/gate-stamp.json
+++ b/package/bsi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bsi/package.json
+++ b/package/bsi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-bsi",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for bsi",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ca/build.gradle.kts
+++ b/package/ca/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ca/gate-stamp.json
+++ b/package/ca/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ca/package.json
+++ b/package/ca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ca",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ca",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/certn/build.gradle.kts
+++ b/package/certn/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/certn/gate-stamp.json
+++ b/package/certn/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/certn/package.json
+++ b/package/certn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-certn",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for certn",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/chainguard/build.gradle.kts
+++ b/package/chainguard/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/chainguard/gate-stamp.json
+++ b/package/chainguard/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/chainguard/package.json
+++ b/package/chainguard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-chainguard",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A control plane for your software supply chain",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/checkov/build.gradle.kts
+++ b/package/checkov/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/checkov/gate-stamp.json
+++ b/package/checkov/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/checkov/package.json
+++ b/package/checkov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-checkov",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Checkov scans cloud infrastructure configurations to find misconfigurations before they're deployed.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/checkpoint/build.gradle.kts
+++ b/package/checkpoint/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/checkpoint/gate-stamp.json
+++ b/package/checkpoint/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/checkpoint/package.json
+++ b/package/checkpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-checkpoint",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Check Point Software Technologies",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/checkr/build.gradle.kts
+++ b/package/checkr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/checkr/gate-stamp.json
+++ b/package/checkr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/checkr/package.json
+++ b/package/checkr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-checkr",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for checkr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/chef/build.gradle.kts
+++ b/package/chef/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/chef/gate-stamp.json
+++ b/package/chef/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/chef/package.json
+++ b/package/chef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-chef",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Chef Software Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/circleci/build.gradle.kts
+++ b/package/circleci/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/circleci/gate-stamp.json
+++ b/package/circleci/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/circleci/package.json
+++ b/package/circleci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-circleci",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for circleci",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cis/build.gradle.kts
+++ b/package/cis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cis/gate-stamp.json
+++ b/package/cis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cis/package.json
+++ b/package/cis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cis",
-  "version": "0.1.8",
+  "version": "1.0.0",
   "description": "Vendor package for cis",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cisa/build.gradle.kts
+++ b/package/cisa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cisa/gate-stamp.json
+++ b/package/cisa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cisa/package.json
+++ b/package/cisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cisa",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "CISA works with partners to defend against today’s threats and collaborate to build a more secure and resilient infrastructure for the future.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cisco/build.gradle.kts
+++ b/package/cisco/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cisco/gate-stamp.json
+++ b/package/cisco/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cisco/package.json
+++ b/package/cisco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cisco",
-  "version": "1.0.14",
+  "version": "2.0.0",
   "description": "Vendor package for cisco",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/citrix/build.gradle.kts
+++ b/package/citrix/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/citrix/gate-stamp.json
+++ b/package/citrix/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/citrix/package.json
+++ b/package/citrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-citrix",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "description": "Vendor package for citrix.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/clockify/build.gradle.kts
+++ b/package/clockify/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/clockify/gate-stamp.json
+++ b/package/clockify/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/clockify/package.json
+++ b/package/clockify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-clockify",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Clockify",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

20 vendors migrated to gradle (`zb.content`) + zbb publish. Alphabetical sweep from `base44` to `clockify`, skipping logo-issue vendors (separate fix).

| vendor | old → new |
|---|---|
| base44 | 1.2.2 → 2.0.0 |
| beyondtrust | 0.3.7 → 1.0.0 |
| bitdefender | 1.2.2 → 2.0.0 |
| bm | 1.0.4 → 2.0.0 |
| box | 1.0.12 → 2.0.0 |
| br | 1.0.4 → 2.0.0 |
| bsi | 1.0.4 → 2.0.0 |
| ca | 1.0.4 → 2.0.0 |
| certn | 1.0.13 → 2.0.0 |
| chainguard | 1.0.4 → 2.0.0 |
| checkov | 1.0.6 → 2.0.0 |
| checkpoint | 1.0.4 → 2.0.0 |
| checkr | 1.0.12 → 2.0.0 |
| chef | 1.2.2 → 2.0.0 |
| circleci | 1.0.12 → 2.0.0 |
| cis | 0.1.8 → 1.0.0 |
| cisa | 1.0.7 → 2.0.0 |
| cisco | 1.0.14 → 2.0.0 |
| citrix | 1.1.7 → 2.0.0 |
| clockify | 1.0.4 → 2.0.0 |

**Skipped (logo issues — needs separate fix):**
- `bs` (195B), `ch` (183B), `cl` (249B), `co` (201B) — under 500B floor
- `certero`, `clarizen`, `clickup` — no logo file present

## Test plan

- [x] `./gradlew :<v>:gate` passes for each of the 20
- [ ] After merge: matrix publish (20 legs), bundle auto-refreshes to 1.0.3