### PR TITLE
feat: migrate vendor batch 4 (20 incl. logo backlog)

### DIFF
--- a/package/ae/build.gradle.kts
+++ b/package/ae/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ae/gate-stamp.json
+++ b/package/ae/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ae/package.json
+++ b/package/ae/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ae",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ae",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/aikido/build.gradle.kts
+++ b/package/aikido/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aikido/gate-stamp.json
+++ b/package/aikido/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/aikido/package.json
+++ b/package/aikido/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-aikido",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Aikido Security",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/at/build.gradle.kts
+++ b/package/at/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/at/gate-stamp.json
+++ b/package/at/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/at/package.json
+++ b/package/at/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-at",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for at",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/be/build.gradle.kts
+++ b/package/be/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/be/gate-stamp.json
+++ b/package/be/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/be/package.json
+++ b/package/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-be",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for be",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/beanstalk/build.gradle.kts
+++ b/package/beanstalk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/beanstalk/gate-stamp.json
+++ b/package/beanstalk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/beanstalk/package.json
+++ b/package/beanstalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-beanstalk",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Beanstalk",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/blackduck/build.gradle.kts
+++ b/package/blackduck/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/blackduck/gate-stamp.json
+++ b/package/blackduck/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/blackduck/package.json
+++ b/package/blackduck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-blackduck",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Black Duck",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/blueyonder/build.gradle.kts
+++ b/package/blueyonder/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/blueyonder/gate-stamp.json
+++ b/package/blueyonder/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/blueyonder/package.json
+++ b/package/blueyonder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-blueyonder",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Blue Yonder",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/bs/build.gradle.kts
+++ b/package/bs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bs/gate-stamp.json
+++ b/package/bs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bs/package.json
+++ b/package/bs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-bs",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for bs",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/certero/build.gradle.kts
+++ b/package/certero/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/certero/gate-stamp.json
+++ b/package/certero/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/certero/package.json
+++ b/package/certero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-certero",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for Certero",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/ch/build.gradle.kts
+++ b/package/ch/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ch/gate-stamp.json
+++ b/package/ch/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ch/package.json
+++ b/package/ch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ch",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ch",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cl/build.gradle.kts
+++ b/package/cl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cl/gate-stamp.json
+++ b/package/cl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cl/package.json
+++ b/package/cl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cl",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for cl",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/clarizen/build.gradle.kts
+++ b/package/clarizen/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/clarizen/gate-stamp.json
+++ b/package/clarizen/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/clarizen/package.json
+++ b/package/clarizen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-clarizen",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for Clarizen",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/clickup/build.gradle.kts
+++ b/package/clickup/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/clickup/gate-stamp.json
+++ b/package/clickup/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/clickup/package.json
+++ b/package/clickup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-clickup",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for clickup",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cloudflare/build.gradle.kts
+++ b/package/cloudflare/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cloudflare/gate-stamp.json
+++ b/package/cloudflare/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cloudflare/package.json
+++ b/package/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cloudflare",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for cloudflare",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cn/build.gradle.kts
+++ b/package/cn/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cn/gate-stamp.json
+++ b/package/cn/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cn/package.json
+++ b/package/cn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cn",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "vendor package for cn",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cncf/build.gradle.kts
+++ b/package/cncf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cncf/gate-stamp.json
+++ b/package/cncf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cncf/package.json
+++ b/package/cncf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cncf",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Cloud Native Computing Foundation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/co/build.gradle.kts
+++ b/package/co/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/co/gate-stamp.json
+++ b/package/co/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/co/package.json
+++ b/package/co/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-co",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for co",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/codeai/build.gradle.kts
+++ b/package/codeai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/codeai/gate-stamp.json
+++ b/package/codeai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/codeai/package.json
+++ b/package/codeai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-codeai",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for CodeAI",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/codeium/build.gradle.kts
+++ b/package/codeium/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/codeium/gate-stamp.json
+++ b/package/codeium/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/codeium/package.json
+++ b/package/codeium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-codeium",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Codeium",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/codexai/build.gradle.kts
+++ b/package/codexai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/codexai/gate-stamp.json
+++ b/package/codexai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/codexai/package.json
+++ b/package/codexai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-codexai",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for CodexAI",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Migrates 20 more vendors to gradle. Includes the 14-vendor backlog that the logo validator was previously rejecting — unblocked by `6afaf31d` (replaced size-floor heuristic with content check) and the always-applicable "logos are optional" early-return.

### Backlog unblocked by the validator fix (14)

**Country-flag SVGs** (were failing the 500B floor; now pass the `<svg>` content check):

| vendor | old → new | logo |
|---|---|---|
| ae | 1.0.4 → 2.0.0 | 224B (UAE flag) |
| aikido | 1.0.4 → 2.0.0 | 392B |
| at | 1.0.4 → 2.0.0 | 218B (Austria flag) |
| be | 1.0.4 → 2.0.0 | 182B (Belgium flag) |
| bs | 1.0.4 → 2.0.0 | 195B (Bahamas flag) |
| ch | 1.0.4 → 2.0.0 | 183B (Switzerland flag) |
| cl | 1.0.4 → 2.0.0 | 249B (Chile flag) |
| co | 1.0.4 → 2.0.0 | 201B (Colombia flag) |

**No-logo vendors** (validator early-returns when no logo file is on disk):

| vendor | old → new |
|---|---|
| beanstalk | 1.0.2 → 2.0.0 |
| blackduck | 1.0.2 → 2.0.0 |
| blueyonder | 1.0.2 → 2.0.0 |
| certero | 1.1.3 → 2.0.0 |
| clarizen | 1.1.3 → 2.0.0 |
| clickup | 1.1.3 → 2.0.0 |

### Fresh alphabetical (6)

| vendor | old → new |
|---|---|
| cloudflare | 1.0.13 → 2.0.0 |
| cn | 1.1.3 → 2.0.0 |
| cncf | 1.0.4 → 2.0.0 |
| codeai | 1.0.2 → 2.0.0 |
| codeium | 1.2.2 → 2.0.0 |
| codexai | 1.0.2 → 2.0.0 |

## Test plan

- [x] `./gradlew :<v>:gate` passes for each of the 20
- [ ] After merge: matrix publish, bundle auto-refreshes to 1.0.4