### PR TITLE
feat: migrate vendor batch 5 (50 vendors: ar → fail2ban)

### DIFF
--- a/package/ar/build.gradle.kts
+++ b/package/ar/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ar/gate-stamp.json
+++ b/package/ar/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ar/package.json
+++ b/package/ar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ar",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ar",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/bright/build.gradle.kts
+++ b/package/bright/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/bright/gate-stamp.json
+++ b/package/bright/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/bright/package.json
+++ b/package/bright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-bright",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Bright Security",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/broadcom/build.gradle.kts
+++ b/package/broadcom/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/broadcom/gate-stamp.json
+++ b/package/broadcom/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/broadcom/package.json
+++ b/package/broadcom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-broadcom",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Broadcom",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/complianceforge/build.gradle.kts
+++ b/package/complianceforge/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/complianceforge/gate-stamp.json
+++ b/package/complianceforge/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/complianceforge/package.json
+++ b/package/complianceforge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-complianceforge",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Vendor package for Compliance Forge",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/connectwise/build.gradle.kts
+++ b/package/connectwise/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/connectwise/gate-stamp.json
+++ b/package/connectwise/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/connectwise/package.json
+++ b/package/connectwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-connectwise",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for connectwise",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/coso/build.gradle.kts
+++ b/package/coso/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/coso/gate-stamp.json
+++ b/package/coso/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/coso/package.json
+++ b/package/coso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-coso",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for coso",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cr/build.gradle.kts
+++ b/package/cr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cr/gate-stamp.json
+++ b/package/cr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cr/package.json
+++ b/package/cr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cr",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for cr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/creadly/build.gradle.kts
+++ b/package/creadly/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/creadly/gate-stamp.json
+++ b/package/creadly/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/creadly/package.json
+++ b/package/creadly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-creadly",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "Creadly by Pearson",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/credly/build.gradle.kts
+++ b/package/credly/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/credly/gate-stamp.json
+++ b/package/credly/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/credly/package.json
+++ b/package/credly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-credly",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Credly by Pearson hosts the largest and most-connected digital credential network. We help the world speak a common language of verified knowledge, skills, and abilitie",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/crowdstrike/build.gradle.kts
+++ b/package/crowdstrike/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/crowdstrike/gate-stamp.json
+++ b/package/crowdstrike/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/crowdstrike/package.json
+++ b/package/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-crowdstrike",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "description": "Vendor package for crowdstrike",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/crytek/build.gradle.kts
+++ b/package/crytek/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/crytek/gate-stamp.json
+++ b/package/crytek/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/crytek/package.json
+++ b/package/crytek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-crytek",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Crytek",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/csa/build.gradle.kts
+++ b/package/csa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/csa/gate-stamp.json
+++ b/package/csa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/csa/package.json
+++ b/package/csa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-csa",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Cloud Security Alliance",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cve/build.gradle.kts
+++ b/package/cve/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cve/gate-stamp.json
+++ b/package/cve/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cve/package.json
+++ b/package/cve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cve",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for cve",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cwe/build.gradle.kts
+++ b/package/cwe/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cwe/gate-stamp.json
+++ b/package/cwe/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cwe/package.json
+++ b/package/cwe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cwe",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for cwe",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cybereason/build.gradle.kts
+++ b/package/cybereason/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cybereason/gate-stamp.json
+++ b/package/cybereason/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cybereason/package.json
+++ b/package/cybereason/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cybereason",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Cybereason",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/cyberhaven/build.gradle.kts
+++ b/package/cyberhaven/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cyberhaven/gate-stamp.json
+++ b/package/cyberhaven/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cyberhaven/package.json
+++ b/package/cyberhaven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cyberhaven",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Cyberhaven",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/cyclonedx/build.gradle.kts
+++ b/package/cyclonedx/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cyclonedx/gate-stamp.json
+++ b/package/cyclonedx/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cyclonedx/package.json
+++ b/package/cyclonedx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cyclonedx",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "CycloneDX is the standard for multiple world governments and the defense industrial base.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cycode/build.gradle.kts
+++ b/package/cycode/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cycode/gate-stamp.json
+++ b/package/cycode/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cycode/package.json
+++ b/package/cycode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cycode",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Cycode",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/cyera/build.gradle.kts
+++ b/package/cyera/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cyera/gate-stamp.json
+++ b/package/cyera/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cyera/package.json
+++ b/package/cyera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cyera",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Cyera",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/cypress/build.gradle.kts
+++ b/package/cypress/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cypress/gate-stamp.json
+++ b/package/cypress/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cypress/package.json
+++ b/package/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cypress",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Cypress",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/cz/build.gradle.kts
+++ b/package/cz/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cz/gate-stamp.json
+++ b/package/cz/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cz/package.json
+++ b/package/cz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-cz",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for cz",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/databee/build.gradle.kts
+++ b/package/databee/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/databee/gate-stamp.json
+++ b/package/databee/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/databee/package.json
+++ b/package/databee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-databee",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for DataBee",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/databricks/build.gradle.kts
+++ b/package/databricks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/databricks/gate-stamp.json
+++ b/package/databricks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/databricks/package.json
+++ b/package/databricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-databricks",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Databricks",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/datadog/build.gradle.kts
+++ b/package/datadog/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/datadog/gate-stamp.json
+++ b/package/datadog/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/datadog/package.json
+++ b/package/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-datadog",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for datadog",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/datto/build.gradle.kts
+++ b/package/datto/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/datto/gate-stamp.json
+++ b/package/datto/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/datto/package.json
+++ b/package/datto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-datto",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "description": "Vendor package for datto",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ddn/build.gradle.kts
+++ b/package/ddn/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ddn/gate-stamp.json
+++ b/package/ddn/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ddn/package.json
+++ b/package/ddn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ddn",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for ddn",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/de/build.gradle.kts
+++ b/package/de/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/de/gate-stamp.json
+++ b/package/de/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/de/package.json
+++ b/package/de/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-de",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for de",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/dell/build.gradle.kts
+++ b/package/dell/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dell/gate-stamp.json
+++ b/package/dell/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dell/package.json
+++ b/package/dell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dell",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for dell",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/devsupply/build.gradle.kts
+++ b/package/devsupply/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/devsupply/gate-stamp.json
+++ b/package/devsupply/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/devsupply/package.json
+++ b/package/devsupply/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-devsupply",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for devsupply",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/dhs/build.gradle.kts
+++ b/package/dhs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dhs/gate-stamp.json
+++ b/package/dhs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dhs/package.json
+++ b/package/dhs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dhs",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for dhs",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/disa/build.gradle.kts
+++ b/package/disa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/disa/gate-stamp.json
+++ b/package/disa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/disa/package.json
+++ b/package/disa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-disa",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "Vendor package DISA",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/discord/build.gradle.kts
+++ b/package/discord/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/discord/gate-stamp.json
+++ b/package/discord/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/discord/package.json
+++ b/package/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-discord",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Discord Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/dk/build.gradle.kts
+++ b/package/dk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dk/gate-stamp.json
+++ b/package/dk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dk/package.json
+++ b/package/dk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dk",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for dk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/dnsimple/build.gradle.kts
+++ b/package/dnsimple/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dnsimple/gate-stamp.json
+++ b/package/dnsimple/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dnsimple/package.json
+++ b/package/dnsimple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dnsimple",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for dnsimple",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/docker/build.gradle.kts
+++ b/package/docker/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/docker/gate-stamp.json
+++ b/package/docker/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/docker/package.json
+++ b/package/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-docker",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Docker, Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/document360/build.gradle.kts
+++ b/package/document360/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/document360/gate-stamp.json
+++ b/package/document360/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/document360/package.json
+++ b/package/document360/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-document360",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Document360",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/dod/build.gradle.kts
+++ b/package/dod/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dod/gate-stamp.json
+++ b/package/dod/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dod/package.json
+++ b/package/dod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dod",
-  "version": "0.1.8",
+  "version": "1.0.0",
   "description": "Vendor package for Department of Defense",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/domo/build.gradle.kts
+++ b/package/domo/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/domo/gate-stamp.json
+++ b/package/domo/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/domo/package.json
+++ b/package/domo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-domo",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Domo, Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/doxygen/build.gradle.kts
+++ b/package/doxygen/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/doxygen/gate-stamp.json
+++ b/package/doxygen/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/doxygen/package.json
+++ b/package/doxygen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-doxygen",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Doxygen",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/drcode/build.gradle.kts
+++ b/package/drcode/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/drcode/gate-stamp.json
+++ b/package/drcode/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/drcode/package.json
+++ b/package/drcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-drcode",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Dr. Code",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/dropbox/build.gradle.kts
+++ b/package/dropbox/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dropbox/gate-stamp.json
+++ b/package/dropbox/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dropbox/package.json
+++ b/package/dropbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dropbox",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for dropbox",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/dynatrace/build.gradle.kts
+++ b/package/dynatrace/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dynatrace/gate-stamp.json
+++ b/package/dynatrace/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dynatrace/package.json
+++ b/package/dynatrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-dynatrace",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Dynatrace",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/eclipsefoundation/build.gradle.kts
+++ b/package/eclipsefoundation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eclipsefoundation/gate-stamp.json
+++ b/package/eclipsefoundation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eclipsefoundation/package.json
+++ b/package/eclipsefoundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-eclipsefoundation",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Vendor package for Eclipse Foundation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/epicgames/build.gradle.kts
+++ b/package/epicgames/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/epicgames/gate-stamp.json
+++ b/package/epicgames/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/epicgames/package.json
+++ b/package/epicgames/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-epicgames",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Vendor package for Epic Games",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/es/build.gradle.kts
+++ b/package/es/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/es/gate-stamp.json
+++ b/package/es/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/es/package.json
+++ b/package/es/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-es",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for es",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/build.gradle.kts
+++ b/package/eu/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/gate-stamp.json
+++ b/package/eu/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/package.json
+++ b/package/eu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-eu",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for eu",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/evernote/build.gradle.kts
+++ b/package/evernote/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/evernote/gate-stamp.json
+++ b/package/evernote/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/evernote/package.json
+++ b/package/evernote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-evernote",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Evernote Corporation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/exabeam/build.gradle.kts
+++ b/package/exabeam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/exabeam/gate-stamp.json
+++ b/package/exabeam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/exabeam/package.json
+++ b/package/exabeam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-exabeam",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Exabeam",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/expressvpn/build.gradle.kts
+++ b/package/expressvpn/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/expressvpn/gate-stamp.json
+++ b/package/expressvpn/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/expressvpn/package.json
+++ b/package/expressvpn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-expressvpn",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for ExpressVPN",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/fail2ban/build.gradle.kts
+++ b/package/fail2ban/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fail2ban/gate-stamp.json
+++ b/package/fail2ban/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-5",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fail2ban/package.json
+++ b/package/fail2ban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fail2ban",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Fail2Ban",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Largest batch yet — 50 vendors migrated to gradle (`zb.content`) + zbb publish pipeline. Alphabetical sweep from `ar` through `fail2ban`.

Includes:
- 5 vendors with `0.x` versions bumped to `1.0.0`: `connectwise`, `cve`, `cwe`, `datto`, `dod`
- 45 vendors with `1.x` versions bumped to `2.0.0`

All 50 pass local `:gate` with stamps written.

## Test plan

- [x] `./gradlew :<v>:gate` passes for each of the 50
- [ ] After merge: matrix publish (50 legs), bundle auto-refreshes to 1.0.5

## Progress

After this batch: ~141 / 464 migrated (30%). Continues alphabetical sweep — next batch resumes at `falco`.