### PR TITLE
feat: migrate vendor batch 6 (50 vendors: falco → in)

### DIFF
--- a/package/falco/build.gradle.kts
+++ b/package/falco/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/falco/gate-stamp.json
+++ b/package/falco/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/falco/package.json
+++ b/package/falco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-falco",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Falco is an open-source runtime security platform that allows you to detect and respond to suspicious behavior within Linux containers and applications.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/fi/build.gradle.kts
+++ b/package/fi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fi/gate-stamp.json
+++ b/package/fi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fi/package.json
+++ b/package/fi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fi",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for fi",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/fidoalliance/build.gradle.kts
+++ b/package/fidoalliance/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fidoalliance/gate-stamp.json
+++ b/package/fidoalliance/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fidoalliance/package.json
+++ b/package/fidoalliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fidoalliance",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "The FIDO Alliance is an open industry association with a focused mission: reduce the world’s reliance on passwords. ",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/figma/build.gradle.kts
+++ b/package/figma/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/figma/gate-stamp.json
+++ b/package/figma/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/figma/package.json
+++ b/package/figma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-figma",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Figma",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/filewave/build.gradle.kts
+++ b/package/filewave/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/filewave/gate-stamp.json
+++ b/package/filewave/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/filewave/package.json
+++ b/package/filewave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-filewave",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for FileWave",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/fireeye/build.gradle.kts
+++ b/package/fireeye/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fireeye/gate-stamp.json
+++ b/package/fireeye/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fireeye/package.json
+++ b/package/fireeye/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fireeye",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for FireEye",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/first/build.gradle.kts
+++ b/package/first/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/first/gate-stamp.json
+++ b/package/first/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/first/package.json
+++ b/package/first/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-first",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "FIRST is the premier organization and recognized global leader in incident response",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/fleetsmith/build.gradle.kts
+++ b/package/fleetsmith/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fleetsmith/gate-stamp.json
+++ b/package/fleetsmith/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fleetsmith/package.json
+++ b/package/fleetsmith/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fleetsmith",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for fleetsmith",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/flexera/build.gradle.kts
+++ b/package/flexera/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/flexera/gate-stamp.json
+++ b/package/flexera/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/flexera/package.json
+++ b/package/flexera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-flexera",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for Flexera",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/forcepoint/build.gradle.kts
+++ b/package/forcepoint/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/forcepoint/gate-stamp.json
+++ b/package/forcepoint/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/forcepoint/package.json
+++ b/package/forcepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-forcepoint",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Forcepoint",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/fortinet/build.gradle.kts
+++ b/package/fortinet/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fortinet/gate-stamp.json
+++ b/package/fortinet/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fortinet/package.json
+++ b/package/fortinet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fortinet",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for fortinet",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/fr/build.gradle.kts
+++ b/package/fr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fr/gate-stamp.json
+++ b/package/fr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fr/package.json
+++ b/package/fr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fr",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for fr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/freshworks/build.gradle.kts
+++ b/package/freshworks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/freshworks/gate-stamp.json
+++ b/package/freshworks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/freshworks/package.json
+++ b/package/freshworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-freshworks",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for freshworks",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/fusion/build.gradle.kts
+++ b/package/fusion/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/fusion/gate-stamp.json
+++ b/package/fusion/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/fusion/package.json
+++ b/package/fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-fusion",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Fusion Risk Management",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/gb/build.gradle.kts
+++ b/package/gb/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gb/gate-stamp.json
+++ b/package/gb/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gb/package.json
+++ b/package/gb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-gb",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for gb",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/git/build.gradle.kts
+++ b/package/git/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/git/gate-stamp.json
+++ b/package/git/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/git/package.json
+++ b/package/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-git",
-  "version": "1.0.14",
+  "version": "2.0.0",
   "description": "Vendor package for git",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/gitlab/build.gradle.kts
+++ b/package/gitlab/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gitlab/gate-stamp.json
+++ b/package/gitlab/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gitlab/package.json
+++ b/package/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-gitlab",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for gitlab",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/gliffy/build.gradle.kts
+++ b/package/gliffy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gliffy/gate-stamp.json
+++ b/package/gliffy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gliffy/package.json
+++ b/package/gliffy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-gliffy",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Gliffy",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/goco/build.gradle.kts
+++ b/package/goco/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/goco/gate-stamp.json
+++ b/package/goco/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/goco/package.json
+++ b/package/goco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-goco",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for GoCo",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/godotfoundation/build.gradle.kts
+++ b/package/godotfoundation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/godotfoundation/gate-stamp.json
+++ b/package/godotfoundation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/godotfoundation/package.json
+++ b/package/godotfoundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-godotfoundation",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Godot Foundation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/gr/build.gradle.kts
+++ b/package/gr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gr/gate-stamp.json
+++ b/package/gr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gr/package.json
+++ b/package/gr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-gr",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for gr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/grafeas/build.gradle.kts
+++ b/package/grafeas/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/grafeas/gate-stamp.json
+++ b/package/grafeas/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/grafeas/package.json
+++ b/package/grafeas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-grafeas",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Grafeas",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/greenbone/build.gradle.kts
+++ b/package/greenbone/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/greenbone/gate-stamp.json
+++ b/package/greenbone/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/greenbone/package.json
+++ b/package/greenbone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-greenbone",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Greenbone",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/grokability/build.gradle.kts
+++ b/package/grokability/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/grokability/gate-stamp.json
+++ b/package/grokability/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/grokability/package.json
+++ b/package/grokability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-grokability",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for grokability",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/gruntwork/build.gradle.kts
+++ b/package/gruntwork/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gruntwork/gate-stamp.json
+++ b/package/gruntwork/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gruntwork/package.json
+++ b/package/gruntwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-gruntwork",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Gruntwork",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/gsa/build.gradle.kts
+++ b/package/gsa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gsa/gate-stamp.json
+++ b/package/gsa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gsa/package.json
+++ b/package/gsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-gsa",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Vendor package for GSA",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/halopsa/build.gradle.kts
+++ b/package/halopsa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/halopsa/gate-stamp.json
+++ b/package/halopsa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/halopsa/package.json
+++ b/package/halopsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-halopsa",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "Vendor package for HaloPSA",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/halosecurity/build.gradle.kts
+++ b/package/halosecurity/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/halosecurity/gate-stamp.json
+++ b/package/halosecurity/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/halosecurity/package.json
+++ b/package/halosecurity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-halosecurity",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Halo Security Group",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/halosecuritygroup/build.gradle.kts
+++ b/package/halosecuritygroup/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/halosecuritygroup/gate-stamp.json
+++ b/package/halosecuritygroup/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/halosecuritygroup/package.json
+++ b/package/halosecuritygroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-halosecuritygroup",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Halo Security Group",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/harvest/build.gradle.kts
+++ b/package/harvest/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/harvest/gate-stamp.json
+++ b/package/harvest/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/harvest/package.json
+++ b/package/harvest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-harvest",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Harvest",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/hashicorp/build.gradle.kts
+++ b/package/hashicorp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hashicorp/gate-stamp.json
+++ b/package/hashicorp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hashicorp/package.json
+++ b/package/hashicorp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hashicorp",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for hashicorp",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hexnode/build.gradle.kts
+++ b/package/hexnode/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hexnode/gate-stamp.json
+++ b/package/hexnode/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hexnode/package.json
+++ b/package/hexnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hexnode",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for hexnode",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hidglobal/build.gradle.kts
+++ b/package/hidglobal/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hidglobal/gate-stamp.json
+++ b/package/hidglobal/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hidglobal/package.json
+++ b/package/hidglobal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hidglobal",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for hidglobal",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hk/build.gradle.kts
+++ b/package/hk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hk/gate-stamp.json
+++ b/package/hk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hk/package.json
+++ b/package/hk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hk",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for hk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hl7/build.gradle.kts
+++ b/package/hl7/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hl7/gate-stamp.json
+++ b/package/hl7/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hl7/package.json
+++ b/package/hl7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hl7",
-  "version": "1.0.10-rc.0",
+  "version": "2.0.0",
   "description": "Health Level Seven International (HL7) is a not-for-profit, ANSI-accredited standards developing organization dedicated to providing a comprehensive framework and related standards for the exchange, integration, sharing, and retrieval of electronic health information that supports clinical practice and the management, delivery and evaluation of health services",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hpe/build.gradle.kts
+++ b/package/hpe/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hpe/gate-stamp.json
+++ b/package/hpe/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hpe/package.json
+++ b/package/hpe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hpe",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for hpe",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hu/build.gradle.kts
+++ b/package/hu/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hu/gate-stamp.json
+++ b/package/hu/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hu/package.json
+++ b/package/hu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hu",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for hu",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hubspot/build.gradle.kts
+++ b/package/hubspot/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hubspot/gate-stamp.json
+++ b/package/hubspot/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hubspot/package.json
+++ b/package/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hubspot",
-  "version": "0.5.7",
+  "version": "1.0.0",
   "description": "Vendor package for hubspot",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/hudu/build.gradle.kts
+++ b/package/hudu/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/hudu/gate-stamp.json
+++ b/package/hudu/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/hudu/package.json
+++ b/package/hudu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-hudu",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Vendor package for hudu",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/huggingface/build.gradle.kts
+++ b/package/huggingface/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/huggingface/gate-stamp.json
+++ b/package/huggingface/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/huggingface/package.json
+++ b/package/huggingface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-huggingface",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Hugging Face",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/ibm/build.gradle.kts
+++ b/package/ibm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ibm/gate-stamp.json
+++ b/package/ibm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ibm/package.json
+++ b/package/ibm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ibm",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "IBM",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/icons8/build.gradle.kts
+++ b/package/icons8/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/icons8/gate-stamp.json
+++ b/package/icons8/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/icons8/package.json
+++ b/package/icons8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-icons8",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Icons8",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/id/build.gradle.kts
+++ b/package/id/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/id/gate-stamp.json
+++ b/package/id/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/id/package.json
+++ b/package/id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-id",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for id",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ie/build.gradle.kts
+++ b/package/ie/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ie/gate-stamp.json
+++ b/package/ie/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ie/package.json
+++ b/package/ie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ie",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ie",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iec/build.gradle.kts
+++ b/package/iec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iec/gate-stamp.json
+++ b/package/iec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iec/package.json
+++ b/package/iec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-iec",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for iec",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ietf/build.gradle.kts
+++ b/package/ietf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ietf/gate-stamp.json
+++ b/package/ietf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ietf/package.json
+++ b/package/ietf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ietf",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Internet Engineering Task Force",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iguazio/build.gradle.kts
+++ b/package/iguazio/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iguazio/gate-stamp.json
+++ b/package/iguazio/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iguazio/package.json
+++ b/package/iguazio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-iguazio",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for iguazio",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/il/build.gradle.kts
+++ b/package/il/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/il/gate-stamp.json
+++ b/package/il/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/il/package.json
+++ b/package/il/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-il",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for il",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/imperva/build.gradle.kts
+++ b/package/imperva/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/imperva/gate-stamp.json
+++ b/package/imperva/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/imperva/package.json
+++ b/package/imperva/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-imperva",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Imperva",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/in/build.gradle.kts
+++ b/package/in/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/in/gate-stamp.json
+++ b/package/in/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-6",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/in/package.json
+++ b/package/in/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-in",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for in",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
Next 50 alphabetical. All gated locally. After merge: ~191/464 (41%).