### PR TITLE
feat: migrate vendor batch 7 (50 vendors: infor → miradore)

### DIFF
--- a/package/infor/build.gradle.kts
+++ b/package/infor/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/infor/gate-stamp.json
+++ b/package/infor/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/infor/package.json
+++ b/package/infor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-infor",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Infor",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/intercom/build.gradle.kts
+++ b/package/intercom/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/intercom/gate-stamp.json
+++ b/package/intercom/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/intercom/package.json
+++ b/package/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-intercom",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for intercom",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/isaca/build.gradle.kts
+++ b/package/isaca/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/isaca/gate-stamp.json
+++ b/package/isaca/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/isaca/package.json
+++ b/package/isaca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-isaca",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for isaca",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iso/build.gradle.kts
+++ b/package/iso/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iso/gate-stamp.json
+++ b/package/iso/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iso/package.json
+++ b/package/iso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-iso",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Vendor package for iso",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/it/build.gradle.kts
+++ b/package/it/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/it/gate-stamp.json
+++ b/package/it/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/it/package.json
+++ b/package/it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-it",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for it",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/itarian/build.gradle.kts
+++ b/package/itarian/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/itarian/gate-stamp.json
+++ b/package/itarian/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/itarian/package.json
+++ b/package/itarian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-itarian",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for ITarian",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/itglue/build.gradle.kts
+++ b/package/itglue/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/itglue/gate-stamp.json
+++ b/package/itglue/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/itglue/package.json
+++ b/package/itglue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-itglue",
-  "version": "0.3.6",
+  "version": "1.0.0",
   "description": "Vendor package for itglue",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ivanti/build.gradle.kts
+++ b/package/ivanti/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ivanti/gate-stamp.json
+++ b/package/ivanti/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ivanti/package.json
+++ b/package/ivanti/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ivanti",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "We connect industry-leading unified endpoint management, zero trust security and service management solutions to provide a single pane of glass for enterprises to secure and heal devices, and service end users. ",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/jamf/build.gradle.kts
+++ b/package/jamf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/jamf/gate-stamp.json
+++ b/package/jamf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/jamf/package.json
+++ b/package/jamf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-jamf",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Vendor package for Jamf",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/jetbrains/build.gradle.kts
+++ b/package/jetbrains/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/jetbrains/gate-stamp.json
+++ b/package/jetbrains/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/jetbrains/package.json
+++ b/package/jetbrains/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-jetbrains",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for JetBrains",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/jfrog/build.gradle.kts
+++ b/package/jfrog/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/jfrog/gate-stamp.json
+++ b/package/jfrog/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/jfrog/package.json
+++ b/package/jfrog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-jfrog",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for JFrog",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/jit/build.gradle.kts
+++ b/package/jit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/jit/gate-stamp.json
+++ b/package/jit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/jit/package.json
+++ b/package/jit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-jit",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Jit",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/jp/build.gradle.kts
+++ b/package/jp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/jp/gate-stamp.json
+++ b/package/jp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/jp/package.json
+++ b/package/jp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-jp",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for jp",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/jumpcloud/build.gradle.kts
+++ b/package/jumpcloud/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/jumpcloud/gate-stamp.json
+++ b/package/jumpcloud/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/jumpcloud/package.json
+++ b/package/jumpcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-jumpcloud",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for jumpcloud",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/juniper/build.gradle.kts
+++ b/package/juniper/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/juniper/gate-stamp.json
+++ b/package/juniper/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/juniper/package.json
+++ b/package/juniper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-juniper",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Juniper",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/justworks/build.gradle.kts
+++ b/package/justworks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/justworks/gate-stamp.json
+++ b/package/justworks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/justworks/package.json
+++ b/package/justworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-justworks",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for justworks",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kandji/build.gradle.kts
+++ b/package/kandji/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kandji/gate-stamp.json
+++ b/package/kandji/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kandji/package.json
+++ b/package/kandji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kandji",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for kandji",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kantata/build.gradle.kts
+++ b/package/kantata/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kantata/gate-stamp.json
+++ b/package/kantata/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kantata/package.json
+++ b/package/kantata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kantata",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Kantata",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kapetechnologies/build.gradle.kts
+++ b/package/kapetechnologies/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kapetechnologies/gate-stamp.json
+++ b/package/kapetechnologies/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kapetechnologies/package.json
+++ b/package/kapetechnologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kapetechnologies",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Kape Technologies",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/karmacheck/build.gradle.kts
+++ b/package/karmacheck/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/karmacheck/gate-stamp.json
+++ b/package/karmacheck/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/karmacheck/package.json
+++ b/package/karmacheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-karmacheck",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for karmacheck",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kaseya/build.gradle.kts
+++ b/package/kaseya/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kaseya/gate-stamp.json
+++ b/package/kaseya/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kaseya/package.json
+++ b/package/kaseya/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kaseya",
-  "version": "0.1.8",
+  "version": "1.0.0",
   "description": "Vendor package for kaseya",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ke/build.gradle.kts
+++ b/package/ke/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ke/gate-stamp.json
+++ b/package/ke/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ke/package.json
+++ b/package/ke/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ke",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ke",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kestra/build.gradle.kts
+++ b/package/kestra/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kestra/gate-stamp.json
+++ b/package/kestra/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kestra/package.json
+++ b/package/kestra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kestra",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Kestra",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/kics/build.gradle.kts
+++ b/package/kics/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kics/gate-stamp.json
+++ b/package/kics/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kics/package.json
+++ b/package/kics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kics",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for KICS",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/kinaxis/build.gradle.kts
+++ b/package/kinaxis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kinaxis/gate-stamp.json
+++ b/package/kinaxis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kinaxis/package.json
+++ b/package/kinaxis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kinaxis",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Kinaxis",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/knowbe4/build.gradle.kts
+++ b/package/knowbe4/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/knowbe4/gate-stamp.json
+++ b/package/knowbe4/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/knowbe4/package.json
+++ b/package/knowbe4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-knowbe4",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for knowbe4",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kolide/build.gradle.kts
+++ b/package/kolide/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kolide/gate-stamp.json
+++ b/package/kolide/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kolide/package.json
+++ b/package/kolide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kolide",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for kolide",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kondukto/build.gradle.kts
+++ b/package/kondukto/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kondukto/gate-stamp.json
+++ b/package/kondukto/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kondukto/package.json
+++ b/package/kondukto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kondukto",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Kondukto",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/kr/build.gradle.kts
+++ b/package/kr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kr/gate-stamp.json
+++ b/package/kr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kr/package.json
+++ b/package/kr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kr",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for kr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kubernetes/build.gradle.kts
+++ b/package/kubernetes/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kubernetes/gate-stamp.json
+++ b/package/kubernetes/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kubernetes/package.json
+++ b/package/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kubernetes",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for kubernetes",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kubescape/build.gradle.kts
+++ b/package/kubescape/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kubescape/gate-stamp.json
+++ b/package/kubescape/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kubescape/package.json
+++ b/package/kubescape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kubescape",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Comprehensive Kubernetes Security from Development to Runtime",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/kubesec/build.gradle.kts
+++ b/package/kubesec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/kubesec/gate-stamp.json
+++ b/package/kubesec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/kubesec/package.json
+++ b/package/kubesec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-kubesec",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Kubesec",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/lastpass/build.gradle.kts
+++ b/package/lastpass/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/lastpass/gate-stamp.json
+++ b/package/lastpass/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/lastpass/package.json
+++ b/package/lastpass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-lastpass",
-  "version": "0.3.6",
+  "version": "1.0.0",
   "description": "Vendor package for lastpass",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/latitude/build.gradle.kts
+++ b/package/latitude/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/latitude/gate-stamp.json
+++ b/package/latitude/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/latitude/package.json
+++ b/package/latitude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-latitude",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Latitude",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/legit/build.gradle.kts
+++ b/package/legit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/legit/gate-stamp.json
+++ b/package/legit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/legit/package.json
+++ b/package/legit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-legit",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Legit Security",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/linear/build.gradle.kts
+++ b/package/linear/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/linear/gate-stamp.json
+++ b/package/linear/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/linear/package.json
+++ b/package/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-linear",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for linear",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/linuxfoundation/build.gradle.kts
+++ b/package/linuxfoundation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/linuxfoundation/gate-stamp.json
+++ b/package/linuxfoundation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/linuxfoundation/package.json
+++ b/package/linuxfoundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-linuxfoundation",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Linux Foundation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/logicgate/build.gradle.kts
+++ b/package/logicgate/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/logicgate/gate-stamp.json
+++ b/package/logicgate/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/logicgate/package.json
+++ b/package/logicgate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-logicgate",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for logicgate",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/logicmanager/build.gradle.kts
+++ b/package/logicmanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/logicmanager/gate-stamp.json
+++ b/package/logicmanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/logicmanager/package.json
+++ b/package/logicmanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-logicmanager",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for LogicManager",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/lu/build.gradle.kts
+++ b/package/lu/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/lu/gate-stamp.json
+++ b/package/lu/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/lu/package.json
+++ b/package/lu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-lu",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for lu",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/mabl/build.gradle.kts
+++ b/package/mabl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/mabl/gate-stamp.json
+++ b/package/mabl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/mabl/package.json
+++ b/package/mabl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-mabl",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Mabl",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/malwarebytes/build.gradle.kts
+++ b/package/malwarebytes/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/malwarebytes/gate-stamp.json
+++ b/package/malwarebytes/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/malwarebytes/package.json
+++ b/package/malwarebytes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-malwarebytes",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Malwarebytes",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/manageengine/build.gradle.kts
+++ b/package/manageengine/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/manageengine/gate-stamp.json
+++ b/package/manageengine/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/manageengine/package.json
+++ b/package/manageengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-manageengine",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for ManageEngine",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/mangotechnologies/build.gradle.kts
+++ b/package/mangotechnologies/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/mangotechnologies/gate-stamp.json
+++ b/package/mangotechnologies/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/mangotechnologies/package.json
+++ b/package/mangotechnologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-mangotechnologies",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Mango Technologies, Inc",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/markdownpad/build.gradle.kts
+++ b/package/markdownpad/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/markdownpad/gate-stamp.json
+++ b/package/markdownpad/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/markdownpad/package.json
+++ b/package/markdownpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-markdownpad",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for MarkdownPad",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/mcafee/build.gradle.kts
+++ b/package/mcafee/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/mcafee/gate-stamp.json
+++ b/package/mcafee/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/mcafee/package.json
+++ b/package/mcafee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-mcafee",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for McAfee",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/mend/build.gradle.kts
+++ b/package/mend/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/mend/gate-stamp.json
+++ b/package/mend/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/mend/package.json
+++ b/package/mend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-mend",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Mend",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/mendix/build.gradle.kts
+++ b/package/mendix/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/mendix/gate-stamp.json
+++ b/package/mendix/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/mendix/package.json
+++ b/package/mendix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-mendix",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Mendix",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/metricstream/build.gradle.kts
+++ b/package/metricstream/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/metricstream/gate-stamp.json
+++ b/package/metricstream/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/metricstream/package.json
+++ b/package/metricstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-metricstream",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for MetricStream",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/miradore/build.gradle.kts
+++ b/package/miradore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/miradore/gate-stamp.json
+++ b/package/miradore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-7",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/miradore/package.json
+++ b/package/miradore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-miradore",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Miradore",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
Next 50 alphabetical. 

**Skipped** during this batch (replaced by metricstream + miradore):
- `kite`, `mavenlink` — `logo.svg` is actually an HTML error page (`<!DOCTYPE`). Needs separate logo fix.

All 50 in this PR pass local `:gate`. After merge: ~241/464 (52%).