### PR TITLE
feat: migrate vendor batch 9 (100 vendors: paylocity → tisax)

### DIFF
--- a/package/paylocity/build.gradle.kts
+++ b/package/paylocity/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/paylocity/gate-stamp.json
+++ b/package/paylocity/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/paylocity/package.json
+++ b/package/paylocity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-paylocity",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for paylocity",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/pe/build.gradle.kts
+++ b/package/pe/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pe/gate-stamp.json
+++ b/package/pe/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pe/package.json
+++ b/package/pe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-pe",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for pe",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/penpot/build.gradle.kts
+++ b/package/penpot/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/penpot/gate-stamp.json
+++ b/package/penpot/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/penpot/package.json
+++ b/package/penpot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-penpot",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for penpot",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/perforce/build.gradle.kts
+++ b/package/perforce/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/perforce/gate-stamp.json
+++ b/package/perforce/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/perforce/package.json
+++ b/package/perforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-perforce",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Perforce Software is a leading provider of highly scalable development and DevOps solutions designed to deliver dynamic development, intelligent testing, risk management, and boundaryless collaboration",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ph/build.gradle.kts
+++ b/package/ph/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ph/gate-stamp.json
+++ b/package/ph/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ph/package.json
+++ b/package/ph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ph",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ph",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/pipedrive/build.gradle.kts
+++ b/package/pipedrive/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pipedrive/gate-stamp.json
+++ b/package/pipedrive/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pipedrive/package.json
+++ b/package/pipedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-pipedrive",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Pipedrive",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/pl/build.gradle.kts
+++ b/package/pl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pl/gate-stamp.json
+++ b/package/pl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pl/package.json
+++ b/package/pl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-pl",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for pl",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/playwright/build.gradle.kts
+++ b/package/playwright/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/playwright/gate-stamp.json
+++ b/package/playwright/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/playwright/package.json
+++ b/package/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-playwright",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Playwright",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/postman/build.gradle.kts
+++ b/package/postman/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/postman/gate-stamp.json
+++ b/package/postman/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/postman/package.json
+++ b/package/postman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-postman",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Postman Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/preemptivesolutions/build.gradle.kts
+++ b/package/preemptivesolutions/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/preemptivesolutions/gate-stamp.json
+++ b/package/preemptivesolutions/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/preemptivesolutions/package.json
+++ b/package/preemptivesolutions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-preemptivesolutions",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for PreEmptive Solutions",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/prefect/build.gradle.kts
+++ b/package/prefect/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/prefect/gate-stamp.json
+++ b/package/prefect/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/prefect/package.json
+++ b/package/prefect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-prefect",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Prefect",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/prey/build.gradle.kts
+++ b/package/prey/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/prey/gate-stamp.json
+++ b/package/prey/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/prey/package.json
+++ b/package/prey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-prey",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Prey",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/productive/build.gradle.kts
+++ b/package/productive/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/productive/gate-stamp.json
+++ b/package/productive/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/productive/package.json
+++ b/package/productive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-productive",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Productive",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/proofpoint/build.gradle.kts
+++ b/package/proofpoint/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/proofpoint/gate-stamp.json
+++ b/package/proofpoint/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/proofpoint/package.json
+++ b/package/proofpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-proofpoint",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Proofpoint",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/proprofs/build.gradle.kts
+++ b/package/proprofs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/proprofs/gate-stamp.json
+++ b/package/proprofs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/proprofs/package.json
+++ b/package/proprofs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-proprofs",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for ProProfs",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/protopie/build.gradle.kts
+++ b/package/protopie/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/protopie/gate-stamp.json
+++ b/package/protopie/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/protopie/package.json
+++ b/package/protopie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-protopie",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for ProtoPie",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/pt/build.gradle.kts
+++ b/package/pt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pt/gate-stamp.json
+++ b/package/pt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pt/package.json
+++ b/package/pt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-pt",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for pt",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/pulumi/build.gradle.kts
+++ b/package/pulumi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pulumi/gate-stamp.json
+++ b/package/pulumi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pulumi/package.json
+++ b/package/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-pulumi",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Pulumi",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/puppet/build.gradle.kts
+++ b/package/puppet/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/puppet/gate-stamp.json
+++ b/package/puppet/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/puppet/package.json
+++ b/package/puppet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-puppet",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Puppet Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/qa/build.gradle.kts
+++ b/package/qa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/qa/gate-stamp.json
+++ b/package/qa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/qa/package.json
+++ b/package/qa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-qa",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for qa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/qlik/build.gradle.kts
+++ b/package/qlik/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/qlik/gate-stamp.json
+++ b/package/qlik/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/qlik/package.json
+++ b/package/qlik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-qlik",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Qlik",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/qualys/build.gradle.kts
+++ b/package/qualys/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/qualys/gate-stamp.json
+++ b/package/qualys/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/qualys/package.json
+++ b/package/qualys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-qualys",
-  "version": "0.1.8",
+  "version": "1.0.0",
   "description": "Vendor package for qualys",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/rapidapi/build.gradle.kts
+++ b/package/rapidapi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/rapidapi/gate-stamp.json
+++ b/package/rapidapi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/rapidapi/package.json
+++ b/package/rapidapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-rapidapi",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for RapidAPI",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/readthedocs/build.gradle.kts
+++ b/package/readthedocs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/readthedocs/gate-stamp.json
+++ b/package/readthedocs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/readthedocs/package.json
+++ b/package/readthedocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-readthedocs",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Read the Docs",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/readyplayerme/build.gradle.kts
+++ b/package/readyplayerme/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/readyplayerme/gate-stamp.json
+++ b/package/readyplayerme/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/readyplayerme/package.json
+++ b/package/readyplayerme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-readyplayerme",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Integrate customizable avatars into your game or app in minutes",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/reciprocity/build.gradle.kts
+++ b/package/reciprocity/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/reciprocity/gate-stamp.json
+++ b/package/reciprocity/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/reciprocity/package.json
+++ b/package/reciprocity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-reciprocity",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for reciprocity",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/redcanary/build.gradle.kts
+++ b/package/redcanary/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/redcanary/gate-stamp.json
+++ b/package/redcanary/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/redcanary/package.json
+++ b/package/redcanary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-redcanary",
-  "version": "0.3.6",
+  "version": "1.0.0",
   "description": "Vendor package for redcanary",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/redhat/build.gradle.kts
+++ b/package/redhat/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/redhat/gate-stamp.json
+++ b/package/redhat/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/redhat/package.json
+++ b/package/redhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-redhat",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Red Hat",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/render/build.gradle.kts
+++ b/package/render/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/render/gate-stamp.json
+++ b/package/render/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/render/package.json
+++ b/package/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-render",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for render",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/replit/build.gradle.kts
+++ b/package/replit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/replit/gate-stamp.json
+++ b/package/replit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/replit/package.json
+++ b/package/replit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-replit",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Replit",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/resolver/build.gradle.kts
+++ b/package/resolver/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/resolver/gate-stamp.json
+++ b/package/resolver/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/resolver/package.json
+++ b/package/resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-resolver",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Resolver",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/restassured/build.gradle.kts
+++ b/package/restassured/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/restassured/gate-stamp.json
+++ b/package/restassured/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/restassured/package.json
+++ b/package/restassured/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-restassured",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for RestAssured",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/ridge/build.gradle.kts
+++ b/package/ridge/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ridge/gate-stamp.json
+++ b/package/ridge/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ridge/package.json
+++ b/package/ridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ridge",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Continuous Threat Exposure Management",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/rippling/build.gradle.kts
+++ b/package/rippling/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/rippling/gate-stamp.json
+++ b/package/rippling/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/rippling/package.json
+++ b/package/rippling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-rippling",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for rippling",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/risknet/build.gradle.kts
+++ b/package/risknet/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/risknet/gate-stamp.json
+++ b/package/risknet/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/risknet/package.json
+++ b/package/risknet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-risknet",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Risk.net",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/riskprofiler/build.gradle.kts
+++ b/package/riskprofiler/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/riskprofiler/gate-stamp.json
+++ b/package/riskprofiler/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/riskprofiler/package.json
+++ b/package/riskprofiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-riskprofiler",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for RiskProfiler",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/riskwatch/build.gradle.kts
+++ b/package/riskwatch/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/riskwatch/gate-stamp.json
+++ b/package/riskwatch/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/riskwatch/package.json
+++ b/package/riskwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-riskwatch",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for RiskWatch",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/robotframeworkfoundation/build.gradle.kts
+++ b/package/robotframeworkfoundation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/robotframeworkfoundation/gate-stamp.json
+++ b/package/robotframeworkfoundation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/robotframeworkfoundation/package.json
+++ b/package/robotframeworkfoundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-robotframeworkfoundation",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Robot Framework Foundation",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/rs/build.gradle.kts
+++ b/package/rs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/rs/gate-stamp.json
+++ b/package/rs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/rs/package.json
+++ b/package/rs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-rs",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for rs",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/rs2tech/build.gradle.kts
+++ b/package/rs2tech/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/rs2tech/gate-stamp.json
+++ b/package/rs2tech/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/rs2tech/package.json
+++ b/package/rs2tech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-rs2tech",
-  "version": "0.3.6",
+  "version": "1.0.0",
   "description": "Vendor package for rs2tech",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/rsa/build.gradle.kts
+++ b/package/rsa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/rsa/gate-stamp.json
+++ b/package/rsa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/rsa/package.json
+++ b/package/rsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-rsa",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for rsa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ru/build.gradle.kts
+++ b/package/ru/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ru/gate-stamp.json
+++ b/package/ru/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ru/package.json
+++ b/package/ru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ru",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ru",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/rubrik/build.gradle.kts
+++ b/package/rubrik/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/rubrik/gate-stamp.json
+++ b/package/rubrik/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/rubrik/package.json
+++ b/package/rubrik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-rubrik",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Rubrik",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sa/build.gradle.kts
+++ b/package/sa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/gate-stamp.json
+++ b/package/sa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/package.json
+++ b/package/sa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sa",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for sa",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/safetica/build.gradle.kts
+++ b/package/safetica/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/safetica/gate-stamp.json
+++ b/package/safetica/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/safetica/package.json
+++ b/package/safetica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-safetica",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Safetica",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/salesforce/build.gradle.kts
+++ b/package/salesforce/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/salesforce/gate-stamp.json
+++ b/package/salesforce/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/salesforce/package.json
+++ b/package/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-salesforce",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for salesforce",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/saltstack/build.gradle.kts
+++ b/package/saltstack/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/saltstack/gate-stamp.json
+++ b/package/saltstack/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/saltstack/package.json
+++ b/package/saltstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-saltstack",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for SaltStack Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sap/build.gradle.kts
+++ b/package/sap/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sap/gate-stamp.json
+++ b/package/sap/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sap/package.json
+++ b/package/sap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sap",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for SAP",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/scalefusion/build.gradle.kts
+++ b/package/scalefusion/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/scalefusion/gate-stamp.json
+++ b/package/scalefusion/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/scalefusion/package.json
+++ b/package/scalefusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-scalefusion",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Scalefusion",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/se/build.gradle.kts
+++ b/package/se/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/se/gate-stamp.json
+++ b/package/se/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/se/package.json
+++ b/package/se/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-se",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for se",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/securityscorecard/build.gradle.kts
+++ b/package/securityscorecard/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/securityscorecard/gate-stamp.json
+++ b/package/securityscorecard/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/securityscorecard/package.json
+++ b/package/securityscorecard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-securityscorecard",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for securityscorecard",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sei/build.gradle.kts
+++ b/package/sei/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sei/gate-stamp.json
+++ b/package/sei/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sei/package.json
+++ b/package/sei/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sei",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Software Engineering Institute",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/selenium/build.gradle.kts
+++ b/package/selenium/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/selenium/gate-stamp.json
+++ b/package/selenium/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/selenium/package.json
+++ b/package/selenium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-selenium",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Selenium",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/semgrep/build.gradle.kts
+++ b/package/semgrep/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/semgrep/gate-stamp.json
+++ b/package/semgrep/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/semgrep/package.json
+++ b/package/semgrep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-semgrep",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Semgrep",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/semperis/build.gradle.kts
+++ b/package/semperis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/semperis/gate-stamp.json
+++ b/package/semperis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/semperis/package.json
+++ b/package/semperis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-semperis",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Semperis",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sentinelone/build.gradle.kts
+++ b/package/sentinelone/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sentinelone/gate-stamp.json
+++ b/package/sentinelone/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sentinelone/package.json
+++ b/package/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sentinelone",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for SentinelOne",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sentra/build.gradle.kts
+++ b/package/sentra/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sentra/gate-stamp.json
+++ b/package/sentra/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sentra/package.json
+++ b/package/sentra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sentra",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Sentra",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/servicenow/build.gradle.kts
+++ b/package/servicenow/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/servicenow/gate-stamp.json
+++ b/package/servicenow/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/servicenow/package.json
+++ b/package/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-servicenow",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for servicenow",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sg/build.gradle.kts
+++ b/package/sg/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sg/gate-stamp.json
+++ b/package/sg/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sg/package.json
+++ b/package/sg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sg",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for sg",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/shared_assessments/build.gradle.kts
+++ b/package/shared_assessments/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/shared_assessments/gate-stamp.json
+++ b/package/shared_assessments/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/shared_assessments/package.json
+++ b/package/shared_assessments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-shared_assessments",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for shared_assessments",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sk/build.gradle.kts
+++ b/package/sk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sk/gate-stamp.json
+++ b/package/sk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sk/package.json
+++ b/package/sk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sk",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for sk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sketch/build.gradle.kts
+++ b/package/sketch/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sketch/gate-stamp.json
+++ b/package/sketch/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sketch/package.json
+++ b/package/sketch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sketch",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Sketch",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/slack/build.gradle.kts
+++ b/package/slack/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/slack/gate-stamp.json
+++ b/package/slack/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/slack/package.json
+++ b/package/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-slack",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for slack",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/slsa/build.gradle.kts
+++ b/package/slsa/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/slsa/gate-stamp.json
+++ b/package/slsa/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/slsa/package.json
+++ b/package/slsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-slsa",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "SLSA is a specification for describing and incrementally improving supply chain security, established by industry consensus. It is organized into a series of levels that describe increasing security guarantees.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/smartbear/build.gradle.kts
+++ b/package/smartbear/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/smartbear/gate-stamp.json
+++ b/package/smartbear/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/smartbear/package.json
+++ b/package/smartbear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-smartbear",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for SmartBear",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/smartsheet/build.gradle.kts
+++ b/package/smartsheet/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/smartsheet/gate-stamp.json
+++ b/package/smartsheet/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/smartsheet/package.json
+++ b/package/smartsheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-smartsheet",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for smartsheet",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/snow/build.gradle.kts
+++ b/package/snow/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/snow/gate-stamp.json
+++ b/package/snow/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/snow/package.json
+++ b/package/snow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-snow",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Snow Software",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/snyk/build.gradle.kts
+++ b/package/snyk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/snyk/gate-stamp.json
+++ b/package/snyk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/snyk/package.json
+++ b/package/snyk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-snyk",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "snyk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/solarwinds/build.gradle.kts
+++ b/package/solarwinds/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/solarwinds/gate-stamp.json
+++ b/package/solarwinds/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/solarwinds/package.json
+++ b/package/solarwinds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-solarwinds",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for solarwinds",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sonar/build.gradle.kts
+++ b/package/sonar/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sonar/gate-stamp.json
+++ b/package/sonar/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sonar/package.json
+++ b/package/sonar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sonar",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Clean Code as you write maintainable, readable quality code.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sonatype/build.gradle.kts
+++ b/package/sonatype/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sonatype/gate-stamp.json
+++ b/package/sonatype/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sonatype/package.json
+++ b/package/sonatype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sonatype",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Intercept malicious components with AI-powered behavioral analysis. Protect yourself from malware attacks",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sonrai/build.gradle.kts
+++ b/package/sonrai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sonrai/gate-stamp.json
+++ b/package/sonrai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sonrai/package.json
+++ b/package/sonrai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sonrai",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Sonrai Security",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sophos/build.gradle.kts
+++ b/package/sophos/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sophos/gate-stamp.json
+++ b/package/sophos/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sophos/package.json
+++ b/package/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sophos",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for sophos",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sourcery/build.gradle.kts
+++ b/package/sourcery/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sourcery/gate-stamp.json
+++ b/package/sourcery/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sourcery/package.json
+++ b/package/sourcery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sourcery",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Sourcery",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/spacelift/build.gradle.kts
+++ b/package/spacelift/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/spacelift/gate-stamp.json
+++ b/package/spacelift/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/spacelift/package.json
+++ b/package/spacelift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-spacelift",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Spacelift",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sparta/build.gradle.kts
+++ b/package/sparta/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sparta/gate-stamp.json
+++ b/package/sparta/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sparta/package.json
+++ b/package/sparta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sparta",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for sparta",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sparxsystems/build.gradle.kts
+++ b/package/sparxsystems/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sparxsystems/gate-stamp.json
+++ b/package/sparxsystems/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sparxsystems/package.json
+++ b/package/sparxsystems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sparxsystems",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Sparx Systems",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/spdx/build.gradle.kts
+++ b/package/spdx/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/spdx/gate-stamp.json
+++ b/package/spdx/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/spdx/package.json
+++ b/package/spdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-spdx",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "An open standard capable of representing systems with software components in as SBOMs (Software Bill of Materials) and other AI, data and security references supporting a range of risk management use cases.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/splunk/build.gradle.kts
+++ b/package/splunk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/splunk/gate-stamp.json
+++ b/package/splunk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/splunk/package.json
+++ b/package/splunk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-splunk",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for splunk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/stackpath/build.gradle.kts
+++ b/package/stackpath/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/stackpath/gate-stamp.json
+++ b/package/stackpath/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/stackpath/package.json
+++ b/package/stackpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-stackpath",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for StackPath",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/stixify/build.gradle.kts
+++ b/package/stixify/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/stixify/gate-stamp.json
+++ b/package/stixify/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/stixify/package.json
+++ b/package/stixify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-stixify",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Your automated threat intelligence analyst",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sumologic/build.gradle.kts
+++ b/package/sumologic/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sumologic/gate-stamp.json
+++ b/package/sumologic/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sumologic/package.json
+++ b/package/sumologic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sumologic",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for sumologic",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/superblocks/build.gradle.kts
+++ b/package/superblocks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/superblocks/gate-stamp.json
+++ b/package/superblocks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/superblocks/package.json
+++ b/package/superblocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-superblocks",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Superblocks",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/superops/build.gradle.kts
+++ b/package/superops/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/superops/gate-stamp.json
+++ b/package/superops/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/superops/package.json
+++ b/package/superops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-superops",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for SuperOps",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/surfshark/build.gradle.kts
+++ b/package/surfshark/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/surfshark/gate-stamp.json
+++ b/package/surfshark/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/surfshark/package.json
+++ b/package/surfshark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-surfshark",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Surfshark",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/swift/build.gradle.kts
+++ b/package/swift/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/swift/gate-stamp.json
+++ b/package/swift/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/swift/package.json
+++ b/package/swift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-swift",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for swift",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sword/build.gradle.kts
+++ b/package/sword/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sword/gate-stamp.json
+++ b/package/sword/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sword/package.json
+++ b/package/sword/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sword",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Sword Group",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/syncro/build.gradle.kts
+++ b/package/syncro/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/syncro/gate-stamp.json
+++ b/package/syncro/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/syncro/package.json
+++ b/package/syncro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-syncro",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Syncro",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/synopsys/build.gradle.kts
+++ b/package/synopsys/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/synopsys/gate-stamp.json
+++ b/package/synopsys/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/synopsys/package.json
+++ b/package/synopsys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-synopsys",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Synopsys",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/sysdig/build.gradle.kts
+++ b/package/sysdig/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sysdig/gate-stamp.json
+++ b/package/sysdig/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sysdig/package.json
+++ b/package/sysdig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-sysdig",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Sysdig",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/tableau/build.gradle.kts
+++ b/package/tableau/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tableau/gate-stamp.json
+++ b/package/tableau/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tableau/package.json
+++ b/package/tableau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tableau",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Tableau Software",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/tabnine/build.gradle.kts
+++ b/package/tabnine/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tabnine/gate-stamp.json
+++ b/package/tabnine/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tabnine/package.json
+++ b/package/tabnine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tabnine",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Tabnine",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/tanium/build.gradle.kts
+++ b/package/tanium/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tanium/gate-stamp.json
+++ b/package/tanium/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tanium/package.json
+++ b/package/tanium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tanium",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "Vendor package for tanium",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/tauri/build.gradle.kts
+++ b/package/tauri/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tauri/gate-stamp.json
+++ b/package/tauri/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tauri/package.json
+++ b/package/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tauri",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Tauri",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/telos/build.gradle.kts
+++ b/package/telos/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/telos/gate-stamp.json
+++ b/package/telos/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/telos/package.json
+++ b/package/telos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-telos",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for telos",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/tenable/build.gradle.kts
+++ b/package/tenable/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tenable/gate-stamp.json
+++ b/package/tenable/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tenable/package.json
+++ b/package/tenable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tenable",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for tenable",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/teramind/build.gradle.kts
+++ b/package/teramind/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/teramind/gate-stamp.json
+++ b/package/teramind/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/teramind/package.json
+++ b/package/teramind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-teramind",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Teramind",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/testifysec/build.gradle.kts
+++ b/package/testifysec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/testifysec/gate-stamp.json
+++ b/package/testifysec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/testifysec/package.json
+++ b/package/testifysec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-testifysec",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "We unify developers and cybersecurity teams",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/timesys/build.gradle.kts
+++ b/package/timesys/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/timesys/gate-stamp.json
+++ b/package/timesys/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/timesys/package.json
+++ b/package/timesys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-timesys",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Timesys",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/tisax/build.gradle.kts
+++ b/package/tisax/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tisax/gate-stamp.json
+++ b/package/tisax/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-9",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tisax/package.json
+++ b/package/tisax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tisax",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for tisax",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
Largest batch yet — 100 vendors. All gated locally.

**Skipped in this batch** (broken logos — separate fix):
- `pci_ssc` — `logo.png` doesn't have PNG magic bytes
- `pivotaltracker` — `logo.svg` is actually gzipped (`1f 8b 08 08`)

Replaced by `timesys` and `tisax`.

After merge: ~391/464 (84%).