### PR TITLE
feat: migrate final vendor batch (64 vendors: toggl → zoom)

### DIFF
--- a/package/toggl/build.gradle.kts
+++ b/package/toggl/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/toggl/gate-stamp.json
+++ b/package/toggl/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/toggl/package.json
+++ b/package/toggl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-toggl",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Toggl",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/topdesk/build.gradle.kts
+++ b/package/topdesk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/topdesk/gate-stamp.json
+++ b/package/topdesk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/topdesk/package.json
+++ b/package/topdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-topdesk",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for TOPdesk",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/tr/build.gradle.kts
+++ b/package/tr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tr/gate-stamp.json
+++ b/package/tr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tr/package.json
+++ b/package/tr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tr",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for tr",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/trellix/build.gradle.kts
+++ b/package/trellix/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/trellix/gate-stamp.json
+++ b/package/trellix/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/trellix/package.json
+++ b/package/trellix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-trellix",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Trellix",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/trello/build.gradle.kts
+++ b/package/trello/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/trello/gate-stamp.json
+++ b/package/trello/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/trello/package.json
+++ b/package/trello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-trello",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for trello",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/trendmicro/build.gradle.kts
+++ b/package/trendmicro/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/trendmicro/gate-stamp.json
+++ b/package/trendmicro/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/trendmicro/package.json
+++ b/package/trendmicro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-trendmicro",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Trend Micro",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/trinet/build.gradle.kts
+++ b/package/trinet/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/trinet/gate-stamp.json
+++ b/package/trinet/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/trinet/package.json
+++ b/package/trinet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-trinet",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for trinet",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/trivy/build.gradle.kts
+++ b/package/trivy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/trivy/gate-stamp.json
+++ b/package/trivy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/trivy/package.json
+++ b/package/trivy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-trivy",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Trivy finds vulnerabilities (CVE) & misconfigurations (IaC) across code repositories, binary artifacts, container images, Kubernetes clusters, and more.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/tromzo/build.gradle.kts
+++ b/package/tromzo/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tromzo/gate-stamp.json
+++ b/package/tromzo/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tromzo/package.json
+++ b/package/tromzo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tromzo",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Tromzo",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/trustwave/build.gradle.kts
+++ b/package/trustwave/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/trustwave/gate-stamp.json
+++ b/package/trustwave/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/trustwave/package.json
+++ b/package/trustwave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-trustwave",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Trustwave",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/tw/build.gradle.kts
+++ b/package/tw/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tw/gate-stamp.json
+++ b/package/tw/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tw/package.json
+++ b/package/tw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-tw",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for tw",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/twilio/build.gradle.kts
+++ b/package/twilio/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/twilio/gate-stamp.json
+++ b/package/twilio/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/twilio/package.json
+++ b/package/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-twilio",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for twilio",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/uae/build.gradle.kts
+++ b/package/uae/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/uae/gate-stamp.json
+++ b/package/uae/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/uae/package.json
+++ b/package/uae/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-uae",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for UAE",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/uibakery/build.gradle.kts
+++ b/package/uibakery/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/uibakery/gate-stamp.json
+++ b/package/uibakery/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/uibakery/package.json
+++ b/package/uibakery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-uibakery",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for UI Bakery",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/ukg/build.gradle.kts
+++ b/package/ukg/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ukg/gate-stamp.json
+++ b/package/ukg/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ukg/package.json
+++ b/package/ukg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ukg",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for UKG",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/ul/build.gradle.kts
+++ b/package/ul/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ul/gate-stamp.json
+++ b/package/ul/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ul/package.json
+++ b/package/ul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-ul",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for ul",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/un/build.gradle.kts
+++ b/package/un/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/un/gate-stamp.json
+++ b/package/un/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/un/package.json
+++ b/package/un/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-un",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for un",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/unitytechnologies/build.gradle.kts
+++ b/package/unitytechnologies/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/unitytechnologies/gate-stamp.json
+++ b/package/unitytechnologies/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/unitytechnologies/package.json
+++ b/package/unitytechnologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-unitytechnologies",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Unity Technologies",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/us/build.gradle.kts
+++ b/package/us/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/gate-stamp.json
+++ b/package/us/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/package.json
+++ b/package/us/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ak/build.gradle.kts
+++ b/package/us_ak/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ak/gate-stamp.json
+++ b/package/us_ak/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ak/package.json
+++ b/package/us_ak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_ak",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_ak",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ca/build.gradle.kts
+++ b/package/us_ca/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ca/gate-stamp.json
+++ b/package/us_ca/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ca/package.json
+++ b/package/us_ca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_ca",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_ca",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_co/build.gradle.kts
+++ b/package/us_co/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_co/gate-stamp.json
+++ b/package/us_co/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_co/package.json
+++ b/package/us_co/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_co",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_co",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_il/build.gradle.kts
+++ b/package/us_il/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_il/gate-stamp.json
+++ b/package/us_il/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_il/package.json
+++ b/package/us_il/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_il",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_il",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ma/build.gradle.kts
+++ b/package/us_ma/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ma/gate-stamp.json
+++ b/package/us_ma/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ma/package.json
+++ b/package/us_ma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_ma",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_ma",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_nv/build.gradle.kts
+++ b/package/us_nv/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_nv/gate-stamp.json
+++ b/package/us_nv/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_nv/package.json
+++ b/package/us_nv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_nv",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_nv",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ny/build.gradle.kts
+++ b/package/us_ny/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ny/gate-stamp.json
+++ b/package/us_ny/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ny/package.json
+++ b/package/us_ny/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_ny",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_ny",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_or/build.gradle.kts
+++ b/package/us_or/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_or/gate-stamp.json
+++ b/package/us_or/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_or/package.json
+++ b/package/us_or/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_or",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_or",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_sc/build.gradle.kts
+++ b/package/us_sc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_sc/gate-stamp.json
+++ b/package/us_sc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_sc/package.json
+++ b/package/us_sc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_sc",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_sc",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_te/build.gradle.kts
+++ b/package/us_te/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_te/gate-stamp.json
+++ b/package/us_te/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_te/package.json
+++ b/package/us_te/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_te",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "vendor package for us_te",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_tn/build.gradle.kts
+++ b/package/us_tn/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_tn/gate-stamp.json
+++ b/package/us_tn/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_tn/package.json
+++ b/package/us_tn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_tn",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Vendor package for Tennessee",
   "author": "team@neverfail.com",
   "license": "ISC",

--- a/package/us_tx/build.gradle.kts
+++ b/package/us_tx/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_tx/gate-stamp.json
+++ b/package/us_tx/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_tx/package.json
+++ b/package/us_tx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_tx",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_tx",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_va/build.gradle.kts
+++ b/package/us_va/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_va/gate-stamp.json
+++ b/package/us_va/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_va/package.json
+++ b/package/us_va/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_va",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_va",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_vt/build.gradle.kts
+++ b/package/us_vt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_vt/gate-stamp.json
+++ b/package/us_vt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_vt/package.json
+++ b/package/us_vt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-us_vt",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for us_vt",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/usu/build.gradle.kts
+++ b/package/usu/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/usu/gate-stamp.json
+++ b/package/usu/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/usu/package.json
+++ b/package/usu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-usu",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for USU",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/uy/build.gradle.kts
+++ b/package/uy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/uy/gate-stamp.json
+++ b/package/uy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/uy/package.json
+++ b/package/uy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-uy",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for uy",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/varonis/build.gradle.kts
+++ b/package/varonis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/varonis/gate-stamp.json
+++ b/package/varonis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/varonis/package.json
+++ b/package/varonis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-varonis",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Varonis",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/vectra/build.gradle.kts
+++ b/package/vectra/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/vectra/gate-stamp.json
+++ b/package/vectra/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/vectra/package.json
+++ b/package/vectra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-vectra",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Vectra AI",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/veeam/build.gradle.kts
+++ b/package/veeam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/veeam/gate-stamp.json
+++ b/package/veeam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/veeam/package.json
+++ b/package/veeam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-veeam",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Vendor package for veeam",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/venminder/build.gradle.kts
+++ b/package/venminder/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/venminder/gate-stamp.json
+++ b/package/venminder/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/venminder/package.json
+++ b/package/venminder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-venminder",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for venminder",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/venmo/build.gradle.kts
+++ b/package/venmo/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/venmo/gate-stamp.json
+++ b/package/venmo/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/venmo/package.json
+++ b/package/venmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-venmo",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Venmo makes sending money safe, simple, and social.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/veracode/build.gradle.kts
+++ b/package/veracode/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/veracode/gate-stamp.json
+++ b/package/veracode/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/veracode/package.json
+++ b/package/veracode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-veracode",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Veracode",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/vim/build.gradle.kts
+++ b/package/vim/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/vim/gate-stamp.json
+++ b/package/vim/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/vim/package.json
+++ b/package/vim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-vim",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Vendor package for Vim",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/visily/build.gradle.kts
+++ b/package/visily/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/visily/gate-stamp.json
+++ b/package/visily/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/visily/package.json
+++ b/package/visily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-visily",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Visily",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/vmware/build.gradle.kts
+++ b/package/vmware/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/vmware/gate-stamp.json
+++ b/package/vmware/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/vmware/package.json
+++ b/package/vmware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-vmware",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for vmware",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/vulcan/build.gradle.kts
+++ b/package/vulcan/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/vulcan/gate-stamp.json
+++ b/package/vulcan/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/vulcan/package.json
+++ b/package/vulcan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-vulcan",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Vulcan",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/w3geekery/build.gradle.kts
+++ b/package/w3geekery/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/w3geekery/gate-stamp.json
+++ b/package/w3geekery/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/w3geekery/package.json
+++ b/package/w3geekery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-w3geekery",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Vendor package for W3Geekery",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/wasabi/build.gradle.kts
+++ b/package/wasabi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/wasabi/gate-stamp.json
+++ b/package/wasabi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/wasabi/package.json
+++ b/package/wasabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-wasabi",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Vendor package for wasabi",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/wazuh/build.gradle.kts
+++ b/package/wazuh/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/wazuh/gate-stamp.json
+++ b/package/wazuh/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/wazuh/package.json
+++ b/package/wazuh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-wazuh",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Unified XDR and SIEM protection for endpoints and cloud workloads.",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/webdriverio/build.gradle.kts
+++ b/package/webdriverio/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/webdriverio/gate-stamp.json
+++ b/package/webdriverio/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/webdriverio/package.json
+++ b/package/webdriverio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-webdriverio",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for WebdriverIO",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/whitehouse/build.gradle.kts
+++ b/package/whitehouse/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/whitehouse/gate-stamp.json
+++ b/package/whitehouse/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/whitehouse/package.json
+++ b/package/whitehouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-whitehouse",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "The White House",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/wiremock/build.gradle.kts
+++ b/package/wiremock/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/wiremock/gate-stamp.json
+++ b/package/wiremock/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/wiremock/package.json
+++ b/package/wiremock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-wiremock",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for WireMock",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/wiz/build.gradle.kts
+++ b/package/wiz/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/wiz/gate-stamp.json
+++ b/package/wiz/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/wiz/package.json
+++ b/package/wiz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-wiz",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Vendor package for wiz",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/workday/build.gradle.kts
+++ b/package/workday/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/workday/gate-stamp.json
+++ b/package/workday/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/workday/package.json
+++ b/package/workday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-workday",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for workday",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/workflowmax/build.gradle.kts
+++ b/package/workflowmax/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/workflowmax/gate-stamp.json
+++ b/package/workflowmax/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/workflowmax/package.json
+++ b/package/workflowmax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-workflowmax",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for WorkflowMax",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/workplace/build.gradle.kts
+++ b/package/workplace/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/workplace/gate-stamp.json
+++ b/package/workplace/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/workplace/package.json
+++ b/package/workplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-workplace",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description": "Vendor package for workplace",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/wrike/build.gradle.kts
+++ b/package/wrike/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/wrike/gate-stamp.json
+++ b/package/wrike/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/wrike/package.json
+++ b/package/wrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-wrike",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Wrike",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/yoyogames/build.gradle.kts
+++ b/package/yoyogames/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/yoyogames/gate-stamp.json
+++ b/package/yoyogames/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/yoyogames/package.json
+++ b/package/yoyogames/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-yoyogames",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for YoYo Games",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/za/build.gradle.kts
+++ b/package/za/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/za/gate-stamp.json
+++ b/package/za/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/za/package.json
+++ b/package/za/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-za",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "vendor package for za",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/zed/build.gradle.kts
+++ b/package/zed/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zed/gate-stamp.json
+++ b/package/zed/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zed/package.json
+++ b/package/zed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zed",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Vendor package for Zed Inc.",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/zendesk/build.gradle.kts
+++ b/package/zendesk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zendesk/gate-stamp.json
+++ b/package/zendesk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zendesk/package.json
+++ b/package/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zendesk",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for zendesk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/zenefits/build.gradle.kts
+++ b/package/zenefits/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zenefits/gate-stamp.json
+++ b/package/zenefits/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zenefits/package.json
+++ b/package/zenefits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zenefits",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for zenefits",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/zhuyin/build.gradle.kts
+++ b/package/zhuyin/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zhuyin/gate-stamp.json
+++ b/package/zhuyin/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zhuyin/package.json
+++ b/package/zhuyin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zhuyin",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Vendor package for Zhuyin",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/zoho/build.gradle.kts
+++ b/package/zoho/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zoho/gate-stamp.json
+++ b/package/zoho/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zoho/package.json
+++ b/package/zoho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zoho",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Vendor package for zoho",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/zoom/build.gradle.kts
+++ b/package/zoom/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zoom/gate-stamp.json
+++ b/package/zoom/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/migrate-batch-final",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zoom/package.json
+++ b/package/zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-zoom",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Zoom Video Communications",
   "author": "opignault@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Final alphabetical batch — 64 vendors. After merge, every viable vendor is on the gradle pipeline.

**Remaining post-merge** (~9 vendors requiring pre-fix work, not blocking general rollout):

**Broken logos** (4) — need new logo files before they can pass `:gate`:
- `kite`, `mavenlink` — `logo.svg` is an HTML error page (`<!DOCTYPE`)
- `pci_ssc` — `logo.png` doesn't have PNG magic bytes
- `pivotaltracker` — `logo.svg` is actually gzipped content (`1f 8b 08 08`)

**Flagged in MIGRATION_STATUS.md** (5) — pre-existing schema drift:
- `armis`, `atera`, `lansweeper`, `orcasecurity`, `shortcut` (bad-url flag)

## Coverage after merge

| | count |
|---|---|
| Migrated | 455 / 464 (98.1%) |
| Pending fixes | 9 |