### PR TITLE
feat: fix flagged URLs + migrate armis, atera, lansweeper, orcasecurity, shortcut

### DIFF
--- a/package/armis/build.gradle.kts
+++ b/package/armis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/armis/gate-stamp.json
+++ b/package/armis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/fix-flagged-and-migrate",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/armis/index.yml
+++ b/package/armis/index.yml
@@ -5,5 +5,5 @@ name: Armis
 description: Armis
 type: vendor
 ownerId: 00000000-0000-0000-0000-000000000000
-url: www.armis.com
+url: https://www.armis.com
 logo: https://cdn.auditmation.io/logos/armis.svg

--- a/package/armis/package.json
+++ b/package/armis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-armis",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Armis",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/atera/build.gradle.kts
+++ b/package/atera/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/atera/gate-stamp.json
+++ b/package/atera/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/fix-flagged-and-migrate",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/atera/index.yml
+++ b/package/atera/index.yml
@@ -5,5 +5,5 @@ name: Atera
 description: Atera
 type: vendor
 ownerId: 00000000-0000-0000-0000-000000000000
-url: www.atera.com
+url: https://www.atera.com
 logo: https://cdn.auditmation.io/logos/atera.svg

--- a/package/atera/package.json
+++ b/package/atera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-atera",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Atera",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/lansweeper/build.gradle.kts
+++ b/package/lansweeper/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/lansweeper/gate-stamp.json
+++ b/package/lansweeper/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/fix-flagged-and-migrate",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/lansweeper/index.yml
+++ b/package/lansweeper/index.yml
@@ -5,5 +5,5 @@ name: Lansweeper
 description: Lansweeper
 type: vendor
 ownerId: 00000000-0000-0000-0000-000000000000
-url: www.lansweeper.com
+url: https://www.lansweeper.com
 logo: https://cdn.auditmation.io/logos/lansweeper.svg

--- a/package/lansweeper/package.json
+++ b/package/lansweeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-lansweeper",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Lansweeper",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/orcasecurity/build.gradle.kts
+++ b/package/orcasecurity/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/orcasecurity/gate-stamp.json
+++ b/package/orcasecurity/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/fix-flagged-and-migrate",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/orcasecurity/index.yml
+++ b/package/orcasecurity/index.yml
@@ -5,5 +5,5 @@ name: Orca Security
 description: Orca Security
 type: vendor
 ownerId: 00000000-0000-0000-0000-000000000000
-url: www.orcasecurity.com
+url: https://www.orcasecurity.com
 logo: https://cdn.auditmation.io/logos/orcasecurity.svg

--- a/package/orcasecurity/package.json
+++ b/package/orcasecurity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-orcasecurity",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Vendor package for Orca Security",
   "author": "opignault@zerobias.com",
   "license": "ISC",

--- a/package/shortcut/build.gradle.kts
+++ b/package/shortcut/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/shortcut/gate-stamp.json
+++ b/package/shortcut/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "feat/fix-flagged-and-migrate",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/shortcut/index.yml
+++ b/package/shortcut/index.yml
@@ -6,6 +6,6 @@ type: vendor
 ownerId: 00000000-0000-0000-0000-000000000000
 created: 2022-01-27T13:56:47.342Z
 updated: 2022-01-31T11:30:08.988Z
-url: hhttps://shortcut.com/
+url: https://shortcut.com/
 description: Project management platform, used to be Clubhouse
 logo: https://cdn.auditmation.io/logos/shortcut.svg

--- a/package/shortcut/package.json
+++ b/package/shortcut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/vendor-shortcut",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Vendor package for shortcut",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Fixes the 5 vendors flagged in MIGRATION_STATUS.md with `bad-url` and migrates each to gradle in the same commit.

| vendor | URL before | URL after | version |
|---|---|---|---|
| armis | `www.armis.com` | `https://www.armis.com` | 1.0.4 → 2.0.0 |
| atera | `www.atera.com` | `https://www.atera.com` | 1.0.4 → 2.0.0 |
| lansweeper | `www.lansweeper.com` | `https://www.lansweeper.com` | 1.0.4 → 2.0.0 |
| orcasecurity | `www.orcasecurity.com` | `https://www.orcasecurity.com` | 1.0.4 → 2.0.0 |
| shortcut | `hhttps://shortcut.com/` | `https://shortcut.com/` | 1.0.12 → 2.0.0 |

All 5 were missing the scheme prefix (or had a typo). All 5 pass local `:gate` after fix.

## Coverage

After merge: **462 / 464** vendors on gradle (**99.6%**). Remaining 2: `kite` and `mavenlink` — broken logos with no recoverable canonical source.