### PR TITLE
chore: drop root workspaces + align settings.gradle.kts with org/module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "type": "module",
   "description": "Zerobias vendor artifacts",
   "main": "main.js",
-  "workspaces": [
-    "package/**"
-  ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,14 @@
+// settings.gradle.kts — vendor monorepo
+//
+// Plugin resolution order: mavenLocal (for `publishToMavenLocal` dev builds
+// of build-tools) → GitHub Packages Maven → gradle plugin portal → mavenCentral.
+// Never via `includeBuild` of a sibling repo path: dev iteration goes through
+// `./gradlew publishToMavenLocal` from build-tools so CI and local resolve
+// the artifact the same way.
+
 pluginManagement {
-    // Use local build-tools if available (dev), otherwise pull from GitHub Packages Maven (CI)
-    val localBuildTools = file("../util/packages/build-tools")
-    if (localBuildTools.exists()) {
-        includeBuild(localBuildTools)
-    }
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://maven.pkg.github.com/zerobias-org/util")
             credentials {
@@ -15,7 +19,6 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-    // Resolve latest build-tools from Maven (used in CI when local composite build is absent)
     plugins {
         id("zb.workspace") version "1.+"
         id("zb.base") version "1.+"


### PR DESCRIPTION
## Summary

Two cleanups Chris flagged in Slack — applying `org/vendor` first as the template before fanning out to the rest of the migrated `zerobias-org` content repos.

- **Root `package.json`**: remove `"workspaces": ["package/**"]`. Hoisted root install was blocking per-package `package-lock.json` files from existing; the publish flow checks for them and runs `npm shrinkwrap` before publishing. Without per-package lockfiles, that step is a no-op.
- **`settings.gradle.kts`**: align `pluginManagement` with [`org/module`](https://github.com/zerobias-org/module/blob/main/settings.gradle.kts). Drop `includeBuild("../util/packages/build-tools")` (sibling-path resolution) and resolve via `mavenLocal → maven pkg → portal → mavenCentral`. Dev iteration now goes through `./gradlew publishToMavenLocal` from build-tools so CI and local resolve the artifact the same way. Vendor-specific bits (`rootProject.name = "vendors"`, `zb.content` plugin, depth-1 auto-discover) preserved.

`[skip ci]` is in the commit since no `package/**/build.gradle.kts` changed — `detect` won't matrix any vendor.

## Test plan

- [x] `./gradlew projectPaths` still resolves all 464 vendor projects after the settings change
- [ ] Verify on merge that the `publish.yml` workflow's `detect` job correctly skips (no `package/**/build.gradle.kts` changed)
- [ ] After this lands as the template, fan out the same change to: `suite`, `framework`, `standard`, `benchmark`, `crosswalk`, `pipeline`, `product`, `schema`, `segment` (workspaces + settings.gradle.kts), and `module`, `collectorbot`, `compliance_feature` (settings.gradle.kts only)
- [ ] Separately fix the `org/collectorbot` typo: `GITHUB_ACTOR ?: "zerobias-com"` → `"zerobias-org"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)