### PR TITLE
fix(vendor-hl7): add trailing period to description

### DIFF
--- a/package/hl7/gate-stamp.json
+++ b/package/hl7/gate-stamp.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0-uat.0",
-  "branch": "feat/migrate-batch-6",
+  "branch": "test/hl7-desc-validate",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/hl7/index.yml
+++ b/package/hl7/index.yml
@@ -7,7 +7,7 @@ updated: '2025-02-04T20:15:04.447Z'
 code: hl7
 status: verified
 description: >-
-  Health Level Seven International (HL7) is a not-for-profit, ANSI-accredited standards developing organization dedicated to providing a comprehensive framework and related standards for the exchange, integration, sharing, and retrieval of electronic health information that supports clinical practice and the management, delivery, and evaluation of health services
+  Health Level Seven International (HL7) is a not-for-profit, ANSI-accredited standards developing organization dedicated to providing a comprehensive framework and related standards for the exchange, integration, sharing, and retrieval of electronic health information that supports clinical practice and the management, delivery, and evaluation of health services.
 aliases:
   - Health Level 7
   - HL7 International


### PR DESCRIPTION
Small description copy fix on the HL7 vendor (trailing period in `index.yml`).

**Primary purpose: validate the publish pipeline.** `org/vendor` is a known-good gradle-migrated repo on the same `zbb-publish-reusable` workflow + dataloader preflight. Merging this triggers a vendor `version` job, which lets us see whether the `dataloader --version` preflight failure observed on `auditlogic/pipeline` (run 26828017148) is **systemic** (vendor fails too) or **pipeline-specific** (vendor passes).

Gate passed locally (`./gradlew :hl7:gate`); stamp refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)