### PR TITLE
fix(vendor-snowflake): regenerate gate-stamp with current plugin

### DIFF
--- a/package/snowflake/gate-stamp.json
+++ b/package/snowflake/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-uat.0",
-  "branch": "feat/snowflake-vendor",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "fix/snowflake-gate-stamp",
+  "sourceHash": "be0be8cf70a2fc470ea2d81fe0768e721aaf612f07a663828cc6f3aceac6657f",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",


### PR DESCRIPTION
## Problem
The `publish (snowflake)` job failed preflight: **`gate-stamp.json is missing or invalid`**, even though the stamp is committed and all gate tasks passed.

## Root cause
The committed stamp was written by a **stale cached `zb.content` plugin** that computed an **empty** `sourceHash` (`e3b0c442…`, the SHA of empty input). The current plugin (`1.0.116`, what CI resolves) hashes the package's content files, so CI recomputed a real hash (`be0be8cf…`) and the stamp's empty hash mismatched → `INVALID`.

(Oracle et al. published under the older hashing and aren't re-validated, so they're unaffected — only newly-published packages hit this.)

## Fix
Regenerated with `./gradlew :snowflake:gate --refresh-dependencies` so the stamp's `sourceHash` matches what CI computes. Verified the build passes and the dataloader loads the vendor.

## Follow-up
The 9 product stamps in `zerobias-org/product#31` were generated the same way and need the same regeneration before that batch publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)