### PR TITLE
fix(vendor-scf): regenerate gate-stamp with valid sourceHash

### DIFF
--- a/package/scf/gate-stamp.json
+++ b/package/scf/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.1",
-  "branch": "feat/gradle-marker-credential-issuers",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "main",
+  "sourceHash": "3f99dc0eaf078553ec6876972bc3510aa159d165c56d43e2c5a319f06596d066",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",


### PR DESCRIPTION
vendor-scf had a placeholder gate-stamp (empty sourceHash), so publish fails `source-hash-changed`. Regenerated with the current plugin (valid sourceHash), same as vendor-snowflake #75. Unblocks the SCF vendor publish → CDN logo upload (logos/scf.png).

🤖 Generated with [Claude Code](https://claude.com/claude-code)