### PR TITLE
docs(claude): portable paths, correct registry

### DIFF
--- a/.claude/skills/create-vendor.md
+++ b/.claude/skills/create-vendor.md
@@ -200,7 +200,7 @@ the registry. Content is `plugins { id("zb.content") }` — exactly one line.
     "correct:deps": "tsx ../../scripts/correctDeps.ts"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://pkg.zerobias.org/"
   },
   "files": ["index.yml", "logo.*"],
   "zerobias": {

--- a/.claude/zerobias-org-vendor-shrinkwrap-agent.md
+++ b/.claude/zerobias-org-vendor-shrinkwrap-agent.md
@@ -22,7 +22,7 @@ This agent handles the rebuilding of npm-shrinkwrap.json files for vendor packag
 ## Command Sequence
 
 ```bash
-cd /home/toor/local_zerobiasorg/vendor/package/{vendor}
+cd package/{vendor}    # from the vendor repo root
 rm -f npm-shrinkwrap.json
 npm install
 npm shrinkwrap
@@ -41,7 +41,7 @@ This agent should be run after:
 For vendor `eclipsefoundation`:
 
 ```bash
-cd /home/toor/local_zerobiasorg/vendor/package/eclipsefoundation
+cd package/eclipsefoundation    # from the vendor repo root
 rm -f npm-shrinkwrap.json
 npm install
 npm shrinkwrap


### PR DESCRIPTION
- Shrinkwrap agent doc used another developer's absolute home-dir paths — now repo-relative
- `create-vendor` skill's package.json template pointed `publishConfig.registry` at `npm.pkg.github.com` — corrected to `pkg.zerobias.org` (matches every other repo's docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)